### PR TITLE
Create Path object

### DIFF
--- a/pii_recognition/paths/__init__.py
+++ b/pii_recognition/paths/__init__.py
@@ -1,6 +1,0 @@
-from .path import create_path_subclass
-
-
-DataPath = create_path_subclass(
-    "DataPath", r"datasets/(?P<data_name>[a-zA-Z]+)(?P<version>\d+)/"
-)

--- a/pii_recognition/paths/data_path.py
+++ b/pii_recognition/paths/data_path.py
@@ -1,0 +1,4 @@
+from .path import Path
+
+class DataPath(Path):
+    pattern_str: str = r".*datasets/(?P<data_name>[a-zA-Z]+)(?P<version>\d+)/"

--- a/pii_recognition/paths/data_path.py
+++ b/pii_recognition/paths/data_path.py
@@ -1,4 +1,5 @@
 from .path import Path
 
+
 class DataPath(Path):
     pattern_str: str = r".*datasets/(?P<data_name>[a-zA-Z]+)(?P<version>\d+)/"

--- a/pii_recognition/paths/data_path_test.py
+++ b/pii_recognition/paths/data_path_test.py
@@ -1,0 +1,26 @@
+from .data_path import DataPath
+from pytest import raises
+
+
+def test_DataPath():
+    actual = DataPath("pii_recognition/datasets/conll2003/eng.testa")
+    assert actual.valid == True
+    assert actual.data_name == "conll"
+    assert actual.version == "2003"
+
+    actual = DataPath("/datasets/conll2003/eng.testa")
+    assert actual.valid == True
+    assert actual.data_name == "conll"
+    assert actual.version == "2003"
+
+    actual = DataPath("datasets/conll2003/eng.testa")
+    assert actual.valid == True
+    assert actual.data_name == "conll"
+    assert actual.version == "2003"
+
+    actual = DataPath("broken_path")
+    assert actual.valid == False
+    with raises(AttributeError):
+        getattr(actual, "data_name")
+    with raises(AttributeError):
+        getattr(actual, "version")

--- a/pii_recognition/paths/data_path_test.py
+++ b/pii_recognition/paths/data_path_test.py
@@ -5,18 +5,18 @@ from pytest import raises
 def test_DataPath():
     actual = DataPath("pii_recognition/datasets/conll2003/eng.testa")
     assert actual.valid is True
-    assert actual.data_name == "conll"  # type: ignore
-    assert actual.version == "2003"  # type: ignore
+    assert actual.data_name == "conll"
+    assert actual.version == "2003"
 
     actual = DataPath("/datasets/conll2003/eng.testa")
     assert actual.valid is True
-    assert actual.data_name == "conll"  # type: ignore
-    assert actual.version == "2003"  # type: ignore
+    assert actual.data_name == "conll"
+    assert actual.version == "2003"
 
     actual = DataPath("datasets/conll2003/eng.testa")
     assert actual.valid is True
-    assert actual.data_name == "conll"  # type: ignore
-    assert actual.version == "2003"  # type: ignore
+    assert actual.data_name == "conll"
+    assert actual.version == "2003"
 
     actual = DataPath("broken_path")
     assert actual.valid is False

--- a/pii_recognition/paths/data_path_test.py
+++ b/pii_recognition/paths/data_path_test.py
@@ -4,22 +4,22 @@ from pytest import raises
 
 def test_DataPath():
     actual = DataPath("pii_recognition/datasets/conll2003/eng.testa")
-    assert actual.valid == True
+    assert actual.valid is True
     assert actual.data_name == "conll"
     assert actual.version == "2003"
 
     actual = DataPath("/datasets/conll2003/eng.testa")
-    assert actual.valid == True
+    assert actual.valid is True
     assert actual.data_name == "conll"
     assert actual.version == "2003"
 
     actual = DataPath("datasets/conll2003/eng.testa")
-    assert actual.valid == True
+    assert actual.valid is True
     assert actual.data_name == "conll"
     assert actual.version == "2003"
 
     actual = DataPath("broken_path")
-    assert actual.valid == False
+    assert actual.valid is False
     with raises(AttributeError):
         getattr(actual, "data_name")
     with raises(AttributeError):

--- a/pii_recognition/paths/data_path_test.py
+++ b/pii_recognition/paths/data_path_test.py
@@ -5,18 +5,18 @@ from pytest import raises
 def test_DataPath():
     actual = DataPath("pii_recognition/datasets/conll2003/eng.testa")
     assert actual.valid is True
-    assert actual.data_name == "conll"
-    assert actual.version == "2003"
+    assert actual.data_name == "conll"  # type: ignore
+    assert actual.version == "2003"  # type: ignore
 
     actual = DataPath("/datasets/conll2003/eng.testa")
     assert actual.valid is True
-    assert actual.data_name == "conll"
-    assert actual.version == "2003"
+    assert actual.data_name == "conll"  # type: ignore
+    assert actual.version == "2003"  # type: ignore
 
     actual = DataPath("datasets/conll2003/eng.testa")
     assert actual.valid is True
-    assert actual.data_name == "conll"
-    assert actual.version == "2003"
+    assert actual.data_name == "conll"  # type: ignore
+    assert actual.version == "2003"  # type: ignore
 
     actual = DataPath("broken_path")
     assert actual.valid is False

--- a/pii_recognition/paths/path.py
+++ b/pii_recognition/paths/path.py
@@ -9,9 +9,8 @@ class Path(metaclass=ABCMeta):
     def __init__(self, path: str):
         self.path = path
         matches = self.get_pattern()
-        if matches is None:
+        if matches:
             self.valid = True
-        else:
             self._pattern_to_attrs(matches)
 
     @property

--- a/pii_recognition/paths/path.py
+++ b/pii_recognition/paths/path.py
@@ -12,6 +12,12 @@ class Path(metaclass=ABCMeta):
         if matches:
             self.valid = True
             self._pattern_to_attrs(matches)
+    
+    # Will be invoked regardless whether attribute
+    # exists or not, this fix mypy error due to
+    # dynamic attributes creations
+    def __getattribute__(self, name: str) -> str:
+        return super().__getattribute__(name)
 
     @property
     @abstractmethod

--- a/pii_recognition/paths/path.py
+++ b/pii_recognition/paths/path.py
@@ -1,9 +1,9 @@
 import re
 from typing import Match, Optional, Type
+from abc import ABCMeta, abstractmethod
 
 
-class Path:
-    _pattern_str: Optional[str] = None
+class Path(metaclass=ABCMeta):
     valid: bool = False
 
     def __init__(self, path: str):
@@ -14,11 +14,13 @@ class Path:
         else:
             self._pattern_to_attrs(matches)
 
-    def get_pattern(self) -> Optional[Match]:
-        if not self._pattern_str:
-            raise AttributeError("No pattern has been defined.")
+    @property
+    @abstractmethod
+    def pattern_str(self) -> str:
+        ...
 
-        return re.match(self._pattern_str, self.path)
+    def get_pattern(self) -> Optional[Match]:
+        return re.match(self.pattern_str, self.path)
 
     def _pattern_to_attrs(self, pattern: Match):
         for key, value in pattern.groupdict().items():

--- a/pii_recognition/paths/path.py
+++ b/pii_recognition/paths/path.py
@@ -1,6 +1,6 @@
 import re
 from abc import ABCMeta, abstractmethod
-from typing import Match, Optional, Type
+from typing import Match, Optional
 
 
 class Path(metaclass=ABCMeta):

--- a/pii_recognition/paths/path.py
+++ b/pii_recognition/paths/path.py
@@ -1,17 +1,22 @@
 import re
-from typing import Match, Type
+from typing import Match, Optional, Type
 
 
 class Path:
-    _pattern_str = None
+    _pattern_str: Optional[str] = None
+    valid: bool = False
 
     def __init__(self, path: str):
         self.path = path
-        self._pattern_to_attrs(self.get_pattern())
+        matches = self.get_pattern()
+        if matches is None:
+            self.valid = True
+        else:
+            self._pattern_to_attrs(matches)
 
-    def get_pattern(self) -> Match:
+    def get_pattern(self) -> Optional[Match]:
         if not self._pattern_str:
-            raise AttributeError("Pattern has not been defined.")
+            raise AttributeError("No pattern has been defined.")
 
         return re.match(self._pattern_str, self.path)
 

--- a/pii_recognition/paths/path.py
+++ b/pii_recognition/paths/path.py
@@ -12,7 +12,7 @@ class Path(metaclass=ABCMeta):
         if matches:
             self.valid = True
             self._pattern_to_attrs(matches)
-    
+
     # Will be invoked regardless whether attribute
     # exists or not, this fix mypy error due to
     # dynamic attributes creations

--- a/pii_recognition/paths/path.py
+++ b/pii_recognition/paths/path.py
@@ -1,6 +1,6 @@
 import re
-from typing import Match, Optional, Type
 from abc import ABCMeta, abstractmethod
+from typing import Match, Optional, Type
 
 
 class Path(metaclass=ABCMeta):
@@ -25,7 +25,3 @@ class Path(metaclass=ABCMeta):
     def _pattern_to_attrs(self, pattern: Match):
         for key, value in pattern.groupdict().items():
             setattr(self, key, value)
-
-
-def create_path_subclass(cls_name: str, pattern: str) -> Type[Path]:
-    return type(cls_name, (Path,), {"_pattern_str": pattern})

--- a/pii_recognition/paths/path_test.py
+++ b/pii_recognition/paths/path_test.py
@@ -14,6 +14,6 @@ def test_Path_attributes():
     with patch.object(Path, attribute="get_pattern") as mock_get_pattern:
         mock_get_pattern.return_value.groupdict.return_value = {"version": 0.0}
         actual = Path("fake_path")  # type: ignore
-    assert actual.version == 0.0
+    assert actual.version == 0.0  # type: ignore
     assert actual.path == "fake_path"
     assert actual.valid is True

--- a/pii_recognition/paths/path_test.py
+++ b/pii_recognition/paths/path_test.py
@@ -14,6 +14,6 @@ def test_Path_attributes():
     with patch.object(Path, attribute="get_pattern") as mock_get_pattern:
         mock_get_pattern.return_value.groupdict.return_value = {"version": 0.0}
         actual = Path("fake_path")  # type: ignore
-    assert actual.version == 0.0  # type: ignore
+    assert actual.version == 0.0
     assert actual.path == "fake_path"
     assert actual.valid is True

--- a/pii_recognition/paths/path_test.py
+++ b/pii_recognition/paths/path_test.py
@@ -1,20 +1,19 @@
+from unittest.mock import patch
+
 from .path import Path
-from pytest import raises
-from unittest.mock import patch, Mock
 
 
 @patch.object(Path, attribute="__abstractmethods__", new=set())
 def test_Path_attributes():
     with patch.object(Path, attribute="get_pattern") as mock_get_pattern:
         mock_get_pattern.return_value = None
-        actual = Path("fake_path")
+        actual = Path("fake_path")  # type: ignore
     assert actual.path == "fake_path"
-    assert actual.valid == False
+    assert actual.valid is False
 
     with patch.object(Path, attribute="get_pattern") as mock_get_pattern:
         mock_get_pattern.return_value.groupdict.return_value = {"version": 0.0}
-        actual = Path("fake_path")
+        actual = Path("fake_path")  # type: ignore
     assert actual.version == 0.0
     assert actual.path == "fake_path"
-    assert actual.valid == True
-
+    assert actual.valid is True

--- a/pii_recognition/paths/path_test.py
+++ b/pii_recognition/paths/path_test.py
@@ -1,0 +1,20 @@
+from .path import Path
+from pytest import raises
+from unittest.mock import patch, Mock
+
+
+@patch.object(Path, attribute="__abstractmethods__", new=set())
+def test_Path_attributes():
+    with patch.object(Path, attribute="get_pattern") as mock_get_pattern:
+        mock_get_pattern.return_value = None
+        actual = Path("fake_path")
+    assert actual.path == "fake_path"
+    assert actual.valid == False
+
+    with patch.object(Path, attribute="get_pattern") as mock_get_pattern:
+        mock_get_pattern.return_value.groupdict.return_value = {"version": 0.0}
+        actual = Path("fake_path")
+    assert actual.version == 0.0
+    assert actual.path == "fake_path"
+    assert actual.valid == True
+


### PR DESCRIPTION
### Description
Using regex to find and extract information from a path string, in order to do this, a path object has been created.

### Context
There are multiple evaluation datasets available, e.g., `wnut`, `conll` and possibly many more in future. Each dataset comes with a unique structure and reads only by the particular reader. This data path facilitates the identification of a dataset so that can map to the right behavior to process these data.

This functionality will be called in `prepare_evaluation_data` at #7 line 35. Given a evaluation dataset path, we first extract the name of the dataset and then grab the right reader to decode the data into `X_test` and `y_test`.

###  Mypy issues
Instantiation of a subclass will dynamically build new attributes with `setattr` at runtime, but `mypy` won't recognise those attributes because they are not available in definition. To resolve the issue, `__getattribute__` has been introduced, which grants access to attribute even if it does not exist.

### Checklist
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.