### PR TITLE
Build registry for detokeniser

### DIFF
--- a/pii_recognition/registers/__init__.py
+++ b/pii_recognition/registers/__init__.py
@@ -1,0 +1,3 @@
+from .detokeniser_registry import DetokeniserRegistry
+
+detokeniser_registry = DetokeniserRegistry()

--- a/pii_recognition/registers/detokeniser_registry.py
+++ b/pii_recognition/registers/detokeniser_registry.py
@@ -1,0 +1,12 @@
+from pii_recognition.tokenisation.detokenisers import (
+    space_join_detokensier,
+    treebank_detokeniser,
+)
+
+from .registry import Registry
+
+
+class DetokeniserRegistry(Registry):
+    def add_predefines(self):
+        self.add_item(space_join_detokensier)
+        self.add_item(treebank_detokeniser)

--- a/pii_recognition/registers/detokeniser_registry_test.py
+++ b/pii_recognition/registers/detokeniser_registry_test.py
@@ -1,0 +1,8 @@
+from .detokeniser_registry import DetokeniserRegistry
+
+
+def test_DetokeniserRegistry():
+    actual = DetokeniserRegistry()
+    assert isinstance(actual, dict)
+    assert len(actual.keys()) > 0
+    assert len(actual.keys()) == len(actual.values())

--- a/pii_recognition/registers/detokeniser_registry_test.py
+++ b/pii_recognition/registers/detokeniser_registry_test.py
@@ -5,4 +5,3 @@ def test_DetokeniserRegistry():
     actual = DetokeniserRegistry()
     assert isinstance(actual, dict)
     assert len(actual.keys()) > 0
-    assert len(actual.keys()) == len(actual.values())

--- a/pii_recognition/registers/tokeniser_registry_test.py
+++ b/pii_recognition/registers/tokeniser_registry_test.py
@@ -5,4 +5,3 @@ def test_TokeniserRegistry():
     actual = TokeniserRegistry()
     assert isinstance(actual, dict)
     assert len(actual.keys()) > 0
-    assert len(actual.keys()) == len(actual.values())

--- a/pii_recognition/tokenisation/detokenisers.py
+++ b/pii_recognition/tokenisation/detokenisers.py
@@ -1,4 +1,5 @@
-from typing import List, Callable
+from typing import List
+
 from nltk.tokenize.treebank import TreebankWordDetokenizer
 
 
@@ -8,16 +9,3 @@ def space_join_detokensier(tokens: List[str]) -> str:
 
 def treebank_detokeniser(tokens: List[str]) -> str:
     return TreebankWordDetokenizer().detokenize(tokens)
-
-
-class DetokeniserRegistry:
-    def __init__(self):
-        self.registry = {}
-        self.add_predefined_detokenisers()
-
-    def add_predefined_detokenisers(self):
-        self.add_detokeniser(space_join_detokensier)
-        self.add_detokeniser(treebank_detokeniser)
-
-    def add_detokeniser(self, detokeniser: Callable):
-        self.registry[detokeniser.__name__] = detokeniser


### PR DESCRIPTION
### Description
Add registry for detokeniser. This is the same as #8.

### Context
Detokeniser is used to untokenise a sentence. Datasets like `CONLL` are organised and segmented by tokens, where every sentence is broken into tokens accompanying with POS, entity label ect. However, many ML models in NER would not accept tokens as an input, instead requiring a string as an input. Detokeniser handles the conversion from tokens to a string, so that evaluations can be done bridging different kinds of inputs.

#### Checklist
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.