### PR TITLE
Make config argument optional

### DIFF
--- a/pii_recognition/evaluation/pipeline.py
+++ b/pii_recognition/evaluation/pipeline.py
@@ -12,8 +12,7 @@ from pii_recognition.recognisers.entity_recogniser import EntityRecogniser
 def get_recogniser(
     recogniser_name: str, recogniser_config: Dict = {}
 ) -> Dict[str, EntityRecogniser]:
-    recogniser_class = recogniser_registry[recogniser_name]
-    recogniser_instance = recogniser_class(**recogniser_config)
+    recogniser_instance = recogniser_registry[recogniser_name](recogniser_config)
     return {"recogniser": recogniser_instance}
 
 

--- a/pii_recognition/evaluation/pipeline.py
+++ b/pii_recognition/evaluation/pipeline.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 
 from pakkr import returns
 
@@ -10,9 +10,11 @@ from pii_recognition.recognisers.entity_recogniser import EntityRecogniser
 # recogniser has been injected to meta
 @returns(recogniser=EntityRecogniser)
 def get_recogniser(
-    recogniser_name: str, recogniser_config: Dict = {}
+    recogniser_name: str, recogniser_config: Optional[Dict] = None
 ) -> Dict[str, EntityRecogniser]:
-    recogniser_instance = recogniser_registry[recogniser_name](recogniser_config)
+    recogniser_instance = recogniser_registry.create_instance(
+        recogniser_name, recogniser_config
+    )
     return {"recogniser": recogniser_instance}
 
 

--- a/pii_recognition/evaluation/pipeline_test.py
+++ b/pii_recognition/evaluation/pipeline_test.py
@@ -2,7 +2,8 @@ from unittest.mock import patch
 
 from .pipeline import get_recogniser
 from pii_recognition.registration.registry import Registry
-from typing import Type, Any, Callable
+from typing import Any
+
 
 class RegistryNoConfig:
     # class can be instantiated without passing any args

--- a/pii_recognition/evaluation/pipeline_test.py
+++ b/pii_recognition/evaluation/pipeline_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from .pipeline import get_recogniser
+from pii_recognition.registration.registry import Registry
 
 
 class RegistryNoConfig:
@@ -15,10 +16,10 @@ class RegistryWithConfig:
 
 
 def mock_registry():
-    return {
-        "RegistryNoConfig": RegistryNoConfig,
-        "RegistryWithConfig": RegistryWithConfig,
-    }
+    regsitry = Registry()
+    regsitry.add_item(RegistryNoConfig)
+    regsitry.add_item(RegistryWithConfig)
+    return regsitry
 
 
 @patch("pii_recognition.evaluation.pipeline.recogniser_registry", new=mock_registry())

--- a/pii_recognition/evaluation/pipeline_test.py
+++ b/pii_recognition/evaluation/pipeline_test.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from .pipeline import get_recogniser
 from pii_recognition.registration.registry import Registry
-
+from typing import Type, Any, Callable
 
 class RegistryNoConfig:
     # class can be instantiated without passing any args
@@ -16,7 +16,8 @@ class RegistryWithConfig:
 
 
 def mock_registry():
-    regsitry = Registry()
+    # Any is equivalent to Type[Any]
+    regsitry: Registry[Any] = Registry()
     regsitry.add_item(RegistryNoConfig)
     regsitry.add_item(RegistryWithConfig)
     return regsitry

--- a/pii_recognition/registration/registry.py
+++ b/pii_recognition/registration/registry.py
@@ -1,4 +1,4 @@
-from typing import Generic, Optional, Type, TypeVar
+from typing import Generic, Optional, Type, TypeVar, Dict
 
 T_co = TypeVar("T_co", covariant=True)
 
@@ -10,5 +10,7 @@ class Registry(dict, Generic[T_co]):
         else:
             self[getattr(item, "__name__")] = item
 
-    def create_instance(self, name: str, **config) -> T_co:
-        return self[name](**config)
+    def create_instance(self, name: str, config: Dict = {}) -> T_co:
+        def _create_instance(self, name: str, **config) -> T_co:
+            return self[name](**config)
+        return _create_instance(name, **config)

--- a/pii_recognition/registration/registry.py
+++ b/pii_recognition/registration/registry.py
@@ -1,4 +1,4 @@
-from typing import Generic, Optional, Type, TypeVar, Dict
+from typing import Dict, Generic, Optional, Type, TypeVar
 
 T_co = TypeVar("T_co", covariant=True)
 
@@ -10,7 +10,10 @@ class Registry(dict, Generic[T_co]):
         else:
             self[getattr(item, "__name__")] = item
 
-    def create_instance(self, name: str, config: Dict = {}) -> T_co:
+    def create_instance(self, name: str, config: Optional[Dict] = None) -> T_co:
+        if config is None:
+            config = {}
+
         def _create_instance(name: str, **config) -> T_co:
             return self[name](**config)
 

--- a/pii_recognition/registration/registry.py
+++ b/pii_recognition/registration/registry.py
@@ -11,6 +11,7 @@ class Registry(dict, Generic[T_co]):
             self[getattr(item, "__name__")] = item
 
     def create_instance(self, name: str, config: Dict = {}) -> T_co:
-        def _create_instance(self, name: str, **config) -> T_co:
+        def _create_instance(name: str, **config) -> T_co:
             return self[name](**config)
+
         return _create_instance(name, **config)

--- a/pii_recognition/registration/registry_test.py
+++ b/pii_recognition/registration/registry_test.py
@@ -6,7 +6,7 @@ from .registry import Registry
 def test_Registry_add_item():
     class ToyClass:
         pass
-    
+
     # Any is equivalent to Type[Any]
     actual = Registry[Any]()
 

--- a/pii_recognition/registration/registry_test.py
+++ b/pii_recognition/registration/registry_test.py
@@ -26,6 +26,6 @@ def test_Registry_create_instance():
     registry = Registry[Any]()
     registry.add_item(ToyClass)
 
-    actual = registry.create_instance(name="ToyClass", a="a")
+    actual = registry.create_instance(name="ToyClass", config={"a": "value_a"})
     assert isinstance(actual, ToyClass)
-    assert actual.a == "a"
+    assert actual.a == "value_a"

--- a/pii_recognition/registration/registry_test.py
+++ b/pii_recognition/registration/registry_test.py
@@ -6,7 +6,8 @@ from .registry import Registry
 def test_Registry_add_item():
     class ToyClass:
         pass
-
+    
+    # Any is equivalent to Type[Any]
     actual = Registry[Any]()
 
     actual.add_item(ToyClass)
@@ -23,6 +24,7 @@ def test_Registry_create_instance():
         def __init__(self, a):
             self.a = a
 
+    # Any is equivalent to Type[Any]
     registry = Registry[Any]()
     registry.add_item(ToyClass)
 


### PR DESCRIPTION
### Description
The method `create_instance` has a required argument config. Config is a keyword argument that will be unpacked when instantiating a class. Some of the classes may not require any input arguments, to handle this case, we will make config an optional argument.

#### Checklist
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.