### PR TITLE
Lazy initialisation for model property of a recogniser

### DIFF
--- a/pii_recognition/recognisers/crf_recogniser.py
+++ b/pii_recognition/recognisers/crf_recogniser.py
@@ -6,6 +6,7 @@ from pii_recognition.features.word_to_features import word2features
 from pii_recognition.labels.schema import SpanLabel
 from pii_recognition.labels.span import token_labels_to_span_labels
 from pii_recognition.tokenisation.token_schema import Token
+from pii_recognition.utils import lazy_property
 
 from .entity_recogniser import EntityRecogniser
 
@@ -25,7 +26,7 @@ class CrfRecogniser(EntityRecogniser):
             supported_languages=supported_languages,
         )
 
-    @property
+    @lazy_property
     def model(self) -> Tagger:
         tagger = Tagger()
         tagger.open(self._model_path)

--- a/pii_recognition/recognisers/crf_recogniser.py
+++ b/pii_recognition/recognisers/crf_recogniser.py
@@ -6,7 +6,7 @@ from pii_recognition.features.word_to_features import word2features
 from pii_recognition.labels.schema import SpanLabel
 from pii_recognition.labels.span import token_labels_to_span_labels
 from pii_recognition.tokenisation.token_schema import Token
-from pii_recognition.utils import lazy_property
+from pii_recognition.utils import cached_property
 
 from .entity_recogniser import EntityRecogniser
 
@@ -26,7 +26,7 @@ class CrfRecogniser(EntityRecogniser):
             supported_languages=supported_languages,
         )
 
-    @lazy_property
+    @cached_property
     def model(self) -> Tagger:
         tagger = Tagger()
         tagger.open(self._model_path)

--- a/pii_recognition/recognisers/entity_recogniser.py
+++ b/pii_recognition/recognisers/entity_recogniser.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Any, List, TypeVar
+from typing import List, TypeVar
 
 from pii_recognition.labels.schema import SpanLabel
 
@@ -33,11 +33,6 @@ class EntityRecogniser(metaclass=ABCMeta):
         assert all(
             [language in self.supported_languages for language in asked_languages]
         ), f"Only support {self.supported_languages}, but got {asked_languages}"
-
-    @property
-    @abstractmethod
-    def model(self) -> Any:
-        ...
 
     @abstractmethod
     def analyse(self, text: str, entities: List[str]) -> List[SpanLabel]:

--- a/pii_recognition/recognisers/entity_recogniser.py
+++ b/pii_recognition/recognisers/entity_recogniser.py
@@ -38,6 +38,3 @@ class EntityRecogniser(metaclass=ABCMeta):
     def analyse(self, text: str, entities: List[str]) -> List[SpanLabel]:
         """Anotate asked entities in the text."""
         ...
-
-
-Rec_co = TypeVar("Rec_co", bound=EntityRecogniser)

--- a/pii_recognition/recognisers/entity_recogniser.py
+++ b/pii_recognition/recognisers/entity_recogniser.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import List, TypeVar
+from typing import List
 
 from pii_recognition.labels.schema import SpanLabel
 

--- a/pii_recognition/recognisers/first_letter_uppercase_recogniser.py
+++ b/pii_recognition/recognisers/first_letter_uppercase_recogniser.py
@@ -14,7 +14,6 @@ class FirstLetterUppercaseRecogniser(EntityRecogniser):
     """
 
     PER = "PER"
-    model = None  # abstract property
 
     def __init__(
         self, supported_languages: List[str], tokeniser: Callable[[str], List[Token]]

--- a/pii_recognition/recognisers/flair_recogniser.py
+++ b/pii_recognition/recognisers/flair_recogniser.py
@@ -4,7 +4,7 @@ from flair.data import Sentence
 from flair.models import SequenceTagger
 
 from pii_recognition.labels.schema import SpanLabel
-from pii_recognition.utils import lazy_property
+from pii_recognition.utils import cached_property
 
 from .entity_recogniser import EntityRecogniser
 
@@ -32,7 +32,7 @@ class FlairRecogniser(EntityRecogniser):
             supported_languages=supported_languages,
         )
 
-    @lazy_property
+    @cached_property
     def model(self):
         return SequenceTagger.load(self.model_name)
 

--- a/pii_recognition/recognisers/flair_recogniser.py
+++ b/pii_recognition/recognisers/flair_recogniser.py
@@ -4,6 +4,7 @@ from flair.data import Sentence
 from flair.models import SequenceTagger
 
 from pii_recognition.labels.schema import SpanLabel
+from pii_recognition.utils import lazy_property
 
 from .entity_recogniser import EntityRecogniser
 
@@ -31,7 +32,7 @@ class FlairRecogniser(EntityRecogniser):
             supported_languages=supported_languages,
         )
 
-    @property
+    @lazy_property
     def model(self):
         return SequenceTagger.load(self.model_name)
 

--- a/pii_recognition/recognisers/spacy_recogniser.py
+++ b/pii_recognition/recognisers/spacy_recogniser.py
@@ -4,6 +4,7 @@ import spacy
 from spacy.lang.xx import MultiLanguage
 
 from pii_recognition.labels.schema import SpanLabel
+from pii_recognition.utils import lazy_property
 
 from .entity_recogniser import EntityRecogniser
 
@@ -31,7 +32,7 @@ class SpacyRecogniser(EntityRecogniser):
             supported_languages=supported_languages,
         )
 
-    @property
+    @lazy_property
     def model(self) -> MultiLanguage:
         return spacy.load(self._model_name, disable=["parser", "tagger"])
 

--- a/pii_recognition/recognisers/spacy_recogniser.py
+++ b/pii_recognition/recognisers/spacy_recogniser.py
@@ -4,7 +4,7 @@ import spacy
 from spacy.lang.xx import MultiLanguage
 
 from pii_recognition.labels.schema import SpanLabel
-from pii_recognition.utils import lazy_property
+from pii_recognition.utils import cached_property
 
 from .entity_recogniser import EntityRecogniser
 
@@ -32,7 +32,7 @@ class SpacyRecogniser(EntityRecogniser):
             supported_languages=supported_languages,
         )
 
-    @lazy_property
+    @cached_property
     def model(self) -> MultiLanguage:
         return spacy.load(self._model_name, disable=["parser", "tagger"])
 

--- a/pii_recognition/recognisers/stanza_recogniser.py
+++ b/pii_recognition/recognisers/stanza_recogniser.py
@@ -3,6 +3,7 @@ from typing import List
 from stanza import Pipeline
 
 from pii_recognition.labels.schema import SpanLabel
+from pii_recognition.utils import lazy_property
 
 from .entity_recogniser import EntityRecogniser
 
@@ -30,7 +31,7 @@ class StanzaRecogniser(EntityRecogniser):
             supported_languages=supported_languages,
         )
 
-    @property
+    @lazy_property
     def model(self) -> Pipeline:
         return Pipeline(self.model_name)
 

--- a/pii_recognition/recognisers/stanza_recogniser.py
+++ b/pii_recognition/recognisers/stanza_recogniser.py
@@ -3,7 +3,7 @@ from typing import List
 from stanza import Pipeline
 
 from pii_recognition.labels.schema import SpanLabel
-from pii_recognition.utils import lazy_property
+from pii_recognition.utils import cached_property
 
 from .entity_recogniser import EntityRecogniser
 
@@ -31,7 +31,7 @@ class StanzaRecogniser(EntityRecogniser):
             supported_languages=supported_languages,
         )
 
-    @lazy_property
+    @cached_property
     def model(self) -> Pipeline:
         return Pipeline(self.model_name)
 

--- a/pii_recognition/utils.py
+++ b/pii_recognition/utils.py
@@ -1,7 +1,24 @@
-from typing import Iterable
+from typing import Any, Iterable, Optional, Type
 
 
 def write_iterable_to_text(iterable: Iterable, file_path: str):
     with open(file_path, "w") as f:
         for elem in iterable:
             f.write(str(elem) + "\n")
+
+
+class lazy_property(property):  # class name follows the convention of property
+    def __get__(self, obj: Any, objtype: Optional[Type] = None) -> Any:
+        if self.fget is None:
+            raise AttributeError("unreadable attribute")
+
+        if obj is None:
+            return self
+
+        name = self.fget.__name__
+        if name in obj.__dict__:
+            return obj.__dict__[name]  # cached already
+        else:
+            value = self.fget(obj)  # type: ignore
+            obj.__dict__[name] = value  # saving back to object
+            return value

--- a/pii_recognition/utils.py
+++ b/pii_recognition/utils.py
@@ -7,7 +7,7 @@ def write_iterable_to_text(iterable: Iterable, file_path: str):
             f.write(str(elem) + "\n")
 
 
-class lazy_property(property):  # class name follows the convention of property
+class cached_property(property):  # class name follows the convention of property
     def __get__(self, obj: Any, objtype: Optional[Type] = None) -> Any:
         if self.fget is None:
             raise AttributeError("unreadable attribute")

--- a/pii_recognition/utils_test.py
+++ b/pii_recognition/utils_test.py
@@ -1,10 +1,10 @@
-from pii_recognition.utils import lazy_property
+from pii_recognition.utils import cached_property
 from unittest.mock import patch, Mock
 
 
-def test_lazy_property():
+def test_cached_property():
     class Toy:
-        @lazy_property
+        @cached_property
         def a(self):
             return "value_a"
 
@@ -18,7 +18,7 @@ def test_lazy_property():
     # test 2: called once
     mock_fget = Mock()
     mock_fget.__name__ = "mock_fget"
-    with patch.object(lazy_property, attribute="fget", new=mock_fget):
+    with patch.object(cached_property, attribute="fget", new=mock_fget):
         actual = Toy()
         actual.a
         actual.a

--- a/pii_recognition/utils_test.py
+++ b/pii_recognition/utils_test.py
@@ -1,0 +1,25 @@
+from pii_recognition.utils import lazy_property
+from unittest.mock import patch, Mock
+
+
+def test_lazy_property():
+    class Toy:
+        @lazy_property
+        def a(self):
+            return "value_a"
+
+    # test 1: attribute is there
+    actual = Toy()
+    actual.a
+    assert "a" in actual.__dict__
+    assert actual.a == "value_a"
+    del actual
+
+    # test 2: called once
+    mock_fget = Mock()
+    mock_fget.__name__ = "mock_fget"
+    with patch.object(lazy_property, attribute="fget", new=mock_fget):
+        actual = Toy()
+        actual.a
+        actual.a
+        mock_fget.assert_called_once

--- a/pii_recognition/utils_test.py
+++ b/pii_recognition/utils_test.py
@@ -22,4 +22,4 @@ def test_lazy_property():
         actual = Toy()
         actual.a
         actual.a
-        mock_fget.assert_called_once
+        mock_fget.assert_called_once()


### PR DESCRIPTION
### Description
Using a descriptor to create a property on an object lazily. 

It prevents two issues from happening

- Initialisation takes unnecessarily long
- Repeated evaluations

#### Checklist
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.