### PR TITLE
Add base classes

### DIFF
--- a/pii_recognition/data_readers/reader.py
+++ b/pii_recognition/data_readers/reader.py
@@ -1,0 +1,14 @@
+from abc import ABCMeta, abstractmethod
+from typing import List, Tuple
+
+
+class Reader(metaclass=ABCMeta):
+    def __init__(self, **kwargs):
+        ...
+
+    @abstractmethod
+    def get_evaluation_data(self, file_path: str) -> Tuple[List[str], List[List[str]]]:
+        """
+        Read evaluation data and split into features and labels.
+        """
+        ...

--- a/pii_recognition/tokenisation/detokenisers.py
+++ b/pii_recognition/tokenisation/detokenisers.py
@@ -1,5 +1,13 @@
-from typing import List, Callable
+from abc import ABCMeta, abstractmethod
+from typing import Callable, List
+
 from nltk.tokenize.treebank import TreebankWordDetokenizer
+
+
+class Detokeniser(metaclass=ABCMeta):
+    @abstractmethod
+    def detokenise(self, tokens: List[str]) -> str:
+        ...
 
 
 def space_join_detokensier(tokens: List[str]) -> str:

--- a/pii_recognition/tokenisation/tokenisers.py
+++ b/pii_recognition/tokenisation/tokenisers.py
@@ -1,8 +1,16 @@
+from abc import ABCMeta, abstractmethod
 from typing import List
 
 from nltk.tokenize import TreebankWordTokenizer
 
 from .token_schema import Token
+
+
+class Tokeniser(metaclass=ABCMeta):
+    @abstractmethod
+    def tokenise(self, text: str) -> List[Token]:
+        ...
+
 
 treebank_tokenizer = TreebankWordTokenizer()
 


### PR DESCRIPTION
### Description
Add base classes for reader, tokeniser and detokeniser. `Registry` can only take class items to register. Conll reader, tokenisers and detokenisers are still functions, this PR is the first step of refactoring the functions into classes, having a base class.