### PR TITLE
Create token label class

### DIFF
--- a/pii_recognition/evaluation/model_evaluator.py
+++ b/pii_recognition/evaluation/model_evaluator.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Tuple
 import numpy as np
 
 from pii_recognition.labels.mapping import map_labels, mask_labels
-from pii_recognition.labels.schema import EvalLabel
+from pii_recognition.labels.schema import EvalLabel, TokenLabel
 from pii_recognition.labels.span import span_labels_to_token_labels
 from pii_recognition.recognisers.entity_recogniser import EntityRecogniser
 from pii_recognition.tokenisation import tokeniser_registry
@@ -41,7 +41,7 @@ class ModelEvaluator:
         )
         self._convert_labels = convert_labels
 
-    def get_token_based_prediction(self, text: str) -> List[str]:
+    def get_token_based_prediction(self, text: str) -> List[TokenLabel]:
         recognised_entities = self.recogniser.analyse(text, self.target_entities)
 
         tokens = self._tokeniser.tokenise(text)

--- a/pii_recognition/evaluation/model_evaluator.py
+++ b/pii_recognition/evaluation/model_evaluator.py
@@ -105,7 +105,8 @@ class ModelEvaluator:
         new_annotations = mask_labels(annotations, translated_target_entities)
 
         # make prediction
-        predictions = self.get_token_based_prediction(text)
+        token_label_predictions = self.get_token_based_prediction(text)
+        predictions: List[str] = [pred.entity_type for pred in token_label_predictions]
         if self._convert_labels:
             new_predictions = map_labels(predictions, self._convert_labels)
         else:

--- a/pii_recognition/evaluation/model_evaluator.py
+++ b/pii_recognition/evaluation/model_evaluator.py
@@ -41,6 +41,14 @@ class ModelEvaluator:
         )
         self._convert_labels = convert_labels
 
+    def _validate_predictions(self, predicted: List[str]):
+        asked_entities = set(self.target_entities) | {"O"}
+        predicted_entities = set(predicted)
+        assert predicted_entities.issubset(asked_entities), (
+            f"Predictions contain unasked entities "
+            f"{sorted(list(predicted_entities - asked_entities))}"
+        )
+
     def get_token_based_prediction(self, text: str) -> List[TokenLabel]:
         recognised_entities = self.recogniser.analyse(text, self.target_entities)
 
@@ -48,12 +56,7 @@ class ModelEvaluator:
         token_labels = span_labels_to_token_labels(recognised_entities, tokens)
 
         # validate predictions
-        asked_entities = set(self.target_entities) | {"O"}
-        predicted_entities = set(token_labels)
-        assert predicted_entities.issubset(asked_entities), (
-            f"Predictions contain unasked entities "
-            f"{sorted(list(predicted_entities - asked_entities))}"
-        )
+        self._validate_predictions([label.entity_type for label in token_labels])
 
         return token_labels
 

--- a/pii_recognition/evaluation/model_evaluator_test.py
+++ b/pii_recognition/evaluation/model_evaluator_test.py
@@ -82,7 +82,7 @@ def test_get_token_based_prediction(
         tokeniser=tokeniser_config,
     )
     actual = evaluator.get_token_based_prediction(text)
-    assert actual == ["O", "O", "PER", "O", "LOC", "O"]
+    assert [x.entity_type for x in actual] == ["O", "O", "PER", "O", "LOC", "O"]
 
     # test 2: raise assertion error
     evaluator = ModelEvaluator(

--- a/pii_recognition/labels/schema.py
+++ b/pii_recognition/labels/schema.py
@@ -14,12 +14,10 @@ class SpanLabel:
 
 
 @dataclass
-class TokenLabel(Token):
+class TokenLabel:
     entity_type: str
-
-    @classmethod
-    def from_instance(cls, instance: Token, entity_type: str) -> TokenLabel:
-        return cls(entity_type=entity_type, **asdict(instance))
+    start: int
+    end: int
 
 
 class EvalLabel(NamedTuple):

--- a/pii_recognition/labels/schema.py
+++ b/pii_recognition/labels/schema.py
@@ -1,5 +1,9 @@
-from dataclasses import dataclass
+from __future__ import annotations  # class forward reference
+
+from dataclasses import asdict, dataclass
 from typing import NamedTuple
+
+from pii_recognition.tokenisation.token_schema import Token
 
 
 @dataclass
@@ -7,6 +11,15 @@ class SpanLabel:
     entity_type: str
     start: int
     end: int
+
+
+@dataclass
+class TokenLabel(Token):
+    entity_type: str
+
+    @classmethod
+    def from_instance(cls, instance: Token, entity_type: str) -> TokenLabel:
+        return cls(entity_type=entity_type, **asdict(instance))
 
 
 class EvalLabel(NamedTuple):

--- a/pii_recognition/labels/schema.py
+++ b/pii_recognition/labels/schema.py
@@ -8,7 +8,6 @@ from pii_recognition.tokenisation.token_schema import Token
 
 @dataclass
 class SpanLabel:
-    text: str
     entity_type: str
     start: int
     end: int

--- a/pii_recognition/labels/schema.py
+++ b/pii_recognition/labels/schema.py
@@ -8,6 +8,7 @@ from pii_recognition.tokenisation.token_schema import Token
 
 @dataclass
 class SpanLabel:
+    text: str
     entity_type: str
     start: int
     end: int

--- a/pii_recognition/labels/schema.py
+++ b/pii_recognition/labels/schema.py
@@ -1,9 +1,7 @@
 from __future__ import annotations  # class forward reference
 
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from typing import NamedTuple
-
-from pii_recognition.tokenisation.token_schema import Token
 
 
 @dataclass
@@ -20,6 +18,7 @@ class TokenLabel:
     end: int
 
 
+# TODO: consider to change to dataclass for consistency
 class EvalLabel(NamedTuple):
     annotated: str
     predicted: str

--- a/pii_recognition/labels/span.py
+++ b/pii_recognition/labels/span.py
@@ -22,7 +22,6 @@ def is_substring(
         return False
 
 
-# TODO: outside label
 def span_labels_to_token_labels(
     span_labels: List[SpanLabel], tokens: List[Token]
 ) -> List[TokenLabel]:
@@ -36,6 +35,8 @@ def span_labels_to_token_labels(
     Returns:
         Token based entity labels, e.g., ["O", "O", "LOC", "O"].
     """
+    # TODO: add param to control whether to include outside label
+    # TODO: span_labels and tokens should be ascending order
     labels = ["O"] * len(tokens)  # default is O, no chunck label
 
     for i in range(len(tokens)):
@@ -51,19 +52,18 @@ def span_labels_to_token_labels(
 
 
 def token_labels_to_span_labels(token_labels: List[TokenLabel]) -> List[SpanLabel]:
+    # TODO: token_labels should be ascending order
     span_labels = []
-    num_tokens = len(token_labels)
-    current_span: Dict = asdict(token_labels[0])
+    prior_span: Dict = asdict(token_labels[0])
 
-    if num_tokens == 1:
-        return [SpanLabel(**current_span)]
-    else:
-        for i in range(num_tokens, num_tokens - 1):
-            next_token_label = token_labels[i + 1]
-            if next_token_label.entity_type == current_span["entity_type"]:
-                current_span["end"] = next_token_label.end
-            else:
-                span_labels.append(SpanLabel(**current_span))
-                current_span = asdict(next_token_label)
+    for i in range(1, len(token_labels)):
+        current_token_label = token_labels[i]
+        if current_token_label.entity_type == prior_span["entity_type"]:
+            prior_span["end"] = current_token_label.end
+        else:
+            span_labels.append(SpanLabel(**prior_span))
+            prior_span = asdict(current_token_label)
+
+    span_labels.append(SpanLabel(**prior_span))
 
     return span_labels

--- a/pii_recognition/labels/span.py
+++ b/pii_recognition/labels/span.py
@@ -49,11 +49,12 @@ def span_labels_to_token_labels(
 
     if keep_o_label:
         return [
-            TokenLabel.from_instance(tokens[i], labels[i]) for i in range(len(tokens))
+            TokenLabel(entity_type=labels[i], start=tokens[i].start, end=tokens[i].end)
+            for i in range(len(tokens))
         ]
     else:
         return [
-            TokenLabel.from_instance(tokens[i], labels[i])
+            TokenLabel(entity_type=labels[i], start=tokens[i].start, end=tokens[i].end)
             for i in range(len(tokens))
             if labels[i] != "O"
         ]

--- a/pii_recognition/labels/span.py
+++ b/pii_recognition/labels/span.py
@@ -60,6 +60,7 @@ def span_labels_to_token_labels(
 
 
 def token_labels_to_span_labels(token_labels: List[TokenLabel]) -> List[SpanLabel]:
+    # order matters
     assert is_ascending(
         [label.start for label in token_labels]
     ), "token_labels are not in ascending order"

--- a/pii_recognition/labels/span.py
+++ b/pii_recognition/labels/span.py
@@ -2,7 +2,7 @@ from typing import List, Tuple
 
 from pii_recognition.tokenisation.token_schema import Token
 
-from .schema import SpanLabel
+from .schema import SpanLabel, TokenLabel
 
 
 def is_substring(
@@ -23,7 +23,7 @@ def is_substring(
 
 def span_labels_to_token_labels(
     span_labels: List[SpanLabel], tokens: List[Token]
-) -> List[str]:
+) -> List[TokenLabel]:
     """
     A conversion that breaks entity labeled by spans to tokens.
 
@@ -34,7 +34,7 @@ def span_labels_to_token_labels(
     Returns:
         Token based entity labels, e.g., ["O", "O", "LOC", "O"].
     """
-    token_labels = ["O"] * len(tokens)
+    labels = ["O"] * len(tokens)  # default is O, no chunck label
 
     for i in range(len(tokens)):
         current_token = tokens[i]
@@ -42,9 +42,10 @@ def span_labels_to_token_labels(
             if is_substring(
                 (current_token.start, current_token.end), (label.start, label.end)
             ):
-                token_labels[i] = label.entity_type
+                labels[i] = label.entity_type
                 break
-    return token_labels
+
+    return [TokenLabel.from_instance(tokens[i], labels[i]) for i in range(len(tokens))]
 
 
 def token_labels_to_span_labels(

--- a/pii_recognition/labels/span.py
+++ b/pii_recognition/labels/span.py
@@ -48,31 +48,28 @@ def span_labels_to_token_labels(
     return [TokenLabel.from_instance(tokens[i], labels[i]) for i in range(len(tokens))]
 
 
-def token_labels_to_span_labels(
-    tokens: List[Token], labels: List[str]
-) -> List[SpanLabel]:
-    assert len(tokens) == len(labels), (
-        f"Length mismatch, where len(tokens)={len(tokens)} and "
-        f"len(tags)={len(labels)}"
-    )
-
+def token_labels_to_span_labels(token_labels: List[TokenLabel]) -> List[SpanLabel]:
     span_labels = []
-    segment_start = tokens[0].start
-    segment_end = tokens[0].end
+    segment_start = token_labels[0].start
+    segment_end = token_labels[0].end
 
-    if len(labels) == 1:
-        return [SpanLabel(labels[0], segment_start, segment_end)]
+    if len(token_labels) == 1:
+        return [SpanLabel(token_labels[0].entity_type, segment_start, segment_end)]
 
     # process all except the last one
-    for i in range(1, len(labels)):
-        if labels[i] == labels[i - 1]:
-            segment_end = tokens[i].end
+    for i in range(1, len(token_labels)):
+        if token_labels[i].entity_type == token_labels[i - 1].entity_type:
+            segment_end = token_labels[i].end
         else:
-            span_labels.append(SpanLabel(labels[i - 1], segment_start, segment_end))
-            segment_start = tokens[i].start
-            segment_end = tokens[i].end
+            span_labels.append(
+                SpanLabel(token_labels[i - 1].entity_type, segment_start, segment_end)
+            )
+            segment_start = token_labels[i].start
+            segment_end = token_labels[i].end
 
     # write out the last one
-    segment_end = tokens[-1].end
-    span_labels.append(SpanLabel(labels[-1], segment_start, segment_end))
+    segment_end = token_labels[-1].end
+    span_labels.append(
+        SpanLabel(token_labels[-1].entity_type, segment_start, segment_end)
+    )
     return span_labels

--- a/pii_recognition/labels/span_test.py
+++ b/pii_recognition/labels/span_test.py
@@ -2,7 +2,7 @@ import pytest
 
 from pii_recognition.tokenisation.token_schema import Token
 
-from .schema import SpanLabel
+from .schema import SpanLabel, TokenLabel
 from .span import is_substring, span_labels_to_token_labels, token_labels_to_span_labels
 
 
@@ -18,7 +18,10 @@ def test_is_substring():
 
 
 def test_span_labels_to_token_labels():
-    span_labels = [SpanLabel("PER", 8, 11), SpanLabel("LOC", 17, 26)]
+    span_labels = [
+        SpanLabel("Bob", "PER", 8, 11),
+        SpanLabel("Melbourne", "LOC", 17, 26),
+    ]
     tokens = [
         Token("This", 0, 4),
         Token("is", 5, 7),
@@ -30,12 +33,13 @@ def test_span_labels_to_token_labels():
     actual = span_labels_to_token_labels(span_labels, tokens)
     assert [x.entity_type for x in actual] == ["O", "O", "PER", "O", "LOC", "O"]
 
+    # TODO: add test case where span across multiple tokens
+
 
 def test_token_labels_to_span_labels():
-    tokens = [Token("Luke", 0, 4)]
-    tags = ["PER"]
-    actual = token_labels_to_span_labels(tokens, tags)
-    assert actual == [SpanLabel("PER", 0, 4)]
+    token_labels = [TokenLabel("Luke", 0, 4, "PER")]
+    actual = token_labels_to_span_labels(token_labels)
+    assert actual == [SpanLabel("Luke", "PER", 0, 4)]
 
     tokens = [Token("Luke", 0, 4), Token("Skywalker", 5, 14)]
     tags = ["PER", "PER"]

--- a/pii_recognition/labels/span_test.py
+++ b/pii_recognition/labels/span_test.py
@@ -18,23 +18,25 @@ def test_is_substring():
 
 
 def test_span_labels_to_token_labels():
-    # reference sentence: "This is Bob from Melbourne."
+    # reference sentence: "This is Bob Smith from Melbourne."
     span_labels = [
-        SpanLabel("PER", 8, 11),
-        SpanLabel("LOC", 17, 26),
+        SpanLabel("PER", 8, 17),
+        SpanLabel("LOC", 23, 32),
     ]
     tokens = [
         Token(0, 4),
         Token(5, 7),
         Token(8, 11),
-        Token(12, 16),
-        Token(17, 26),
-        Token(26, 27),
+        Token(12, 17),
+        Token(18, 22),
+        Token(23, 32),
+        Token(32, 33),
     ]
     actual = span_labels_to_token_labels(span_labels, tokens)
-    assert [x.entity_type for x in actual] == ["O", "O", "PER", "O", "LOC", "O"]
+    assert [x.entity_type for x in actual] == ["O", "O", "PER", "PER", "O", "LOC", "O"]
 
-    # TODO: add test case where span across multiple tokens
+    actual = span_labels_to_token_labels(span_labels, tokens, keep_o_label=False)
+    assert [x.entity_type for x in actual] == ["PER", "PER", "LOC"]
 
 
 def test_token_labels_to_span_labels():

--- a/pii_recognition/labels/span_test.py
+++ b/pii_recognition/labels/span_test.py
@@ -91,7 +91,7 @@ def test_token_labels_to_span_labels():
     ]
 
     # test failure
-    token_labels = [TokenLabel(4, 7, "O"), TokenLabel(0, 3, "O"), TokenLabel(7, 8, "O")]
+    token_labels = [TokenLabel("O", 4, 7), TokenLabel("O", 0, 3), TokenLabel("O", 7, 8)]
     with pytest.raises(AssertionError) as err:
         token_labels_to_span_labels(token_labels)
     assert str(err.value) == "token_labels are not in ascending order"

--- a/pii_recognition/labels/span_test.py
+++ b/pii_recognition/labels/span_test.py
@@ -24,13 +24,13 @@ def test_span_labels_to_token_labels():
         SpanLabel("LOC", 23, 32),
     ]
     tokens = [
-        Token(0, 4),
-        Token(5, 7),
-        Token(8, 11),
-        Token(12, 17),
-        Token(18, 22),
-        Token(23, 32),
-        Token(32, 33),
+        Token("This", 0, 4),
+        Token("is", 5, 7),
+        Token("Bob", 8, 11),
+        Token("Smith", 12, 17),
+        Token("from", 18, 22),
+        Token("Melbourne", 23, 32),
+        Token(".", 32, 33),
     ]
     actual = span_labels_to_token_labels(span_labels, tokens)
     assert [x.entity_type for x in actual] == ["O", "O", "PER", "PER", "O", "LOC", "O"]
@@ -41,45 +41,45 @@ def test_span_labels_to_token_labels():
 
 def test_token_labels_to_span_labels():
     #
-    token_labels = [TokenLabel(0, 4, "PER")]
+    token_labels = [TokenLabel("PER", 0, 4)]
     actual = token_labels_to_span_labels(token_labels)
     assert actual == [SpanLabel("PER", 0, 4)]
 
     # text: Luke
     token_labels = [
-        TokenLabel(0, 4, "PER"),
-        TokenLabel(5, 14, "PER"),
+        TokenLabel("PER", 0, 4),
+        TokenLabel("PER", 5, 14),
     ]
     actual = token_labels_to_span_labels(token_labels)
     assert actual == [SpanLabel("PER", 0, 14)]
 
     # text: Luke Skywalker
     token_labels = [
-        TokenLabel(0, 4, "PER"),
-        TokenLabel(5, 14, "PER"),
-        TokenLabel(14, 15, "O"),
+        TokenLabel("PER", 0, 4),
+        TokenLabel("PER", 5, 14),
+        TokenLabel("O", 14, 15),
     ]
     actual = token_labels_to_span_labels(token_labels)
     assert actual == [SpanLabel("PER", 0, 14), SpanLabel("O", 14, 15)]
 
     # text: Luke-Skywalker
-    token_labels = [TokenLabel(0, 5, "PER"), TokenLabel(5, 14, "PER")]
+    token_labels = [TokenLabel("PER", 0, 5), TokenLabel("PER", 5, 14)]
     actual = token_labels_to_span_labels(token_labels)
     assert actual == [SpanLabel("PER", 0, 14)]
 
     # text: one day, Luke Skywalker and Wedge Antilles recover a message
     token_labels = [
-        TokenLabel(0, 3, "O"),
-        TokenLabel(4, 7, "O"),
-        TokenLabel(7, 8, "O"),
-        TokenLabel(9, 13, "PER"),
-        TokenLabel(14, 23, "PER"),
-        TokenLabel(24, 27, "O"),
-        TokenLabel(28, 33, "PER"),
-        TokenLabel(34, 42, "PER"),
-        TokenLabel(43, 50, "O"),
-        TokenLabel(51, 52, "O"),
-        TokenLabel(53, 60, "O"),
+        TokenLabel("O", 0, 3),
+        TokenLabel("O", 4, 7),
+        TokenLabel("O", 7, 8),
+        TokenLabel("PER", 9, 13),
+        TokenLabel("PER", 14, 23),
+        TokenLabel("O", 24, 27),
+        TokenLabel("PER", 28, 33),
+        TokenLabel("PER", 34, 42),
+        TokenLabel("O", 43, 50),
+        TokenLabel("O", 51, 52),
+        TokenLabel("O", 53, 60),
     ]
     actual = token_labels_to_span_labels(token_labels)
     assert actual == [

--- a/pii_recognition/labels/span_test.py
+++ b/pii_recognition/labels/span_test.py
@@ -28,7 +28,7 @@ def test_span_labels_to_token_labels():
         Token(".", 26, 27),
     ]
     actual = span_labels_to_token_labels(span_labels, tokens)
-    assert actual == ["O", "O", "PER", "O", "LOC", "O"]
+    assert [x.entity_type for x in actual] == ["O", "O", "PER", "O", "LOC", "O"]
 
 
 def test_token_labels_to_span_labels():

--- a/pii_recognition/labels/span_test.py
+++ b/pii_recognition/labels/span_test.py
@@ -89,3 +89,9 @@ def test_token_labels_to_span_labels():
         SpanLabel("PER", 28, 42),
         SpanLabel("O", 43, 60),
     ]
+
+    # test failure
+    token_labels = [TokenLabel(4, 7, "O"), TokenLabel(0, 3, "O"), TokenLabel(7, 8, "O")]
+    with pytest.raises(AssertionError) as err:
+        token_labels_to_span_labels(token_labels)
+    assert str(err.value) == "token_labels are not in ascending order"

--- a/pii_recognition/labels/span_test.py
+++ b/pii_recognition/labels/span_test.py
@@ -18,17 +18,18 @@ def test_is_substring():
 
 
 def test_span_labels_to_token_labels():
+    # reference sentence: "This is Bob from Melbourne."
     span_labels = [
-        SpanLabel("Bob", "PER", 8, 11),
-        SpanLabel("Melbourne", "LOC", 17, 26),
+        SpanLabel("PER", 8, 11),
+        SpanLabel("LOC", 17, 26),
     ]
     tokens = [
-        Token("This", 0, 4),
-        Token("is", 5, 7),
-        Token("Bob", 8, 11),
-        Token("from", 12, 16),
-        Token("Melbourne", 17, 26),
-        Token(".", 26, 27),
+        Token(0, 4),
+        Token(5, 7),
+        Token(8, 11),
+        Token(12, 16),
+        Token(17, 26),
+        Token(26, 27),
     ]
     actual = span_labels_to_token_labels(span_labels, tokens)
     assert [x.entity_type for x in actual] == ["O", "O", "PER", "O", "LOC", "O"]
@@ -37,40 +38,48 @@ def test_span_labels_to_token_labels():
 
 
 def test_token_labels_to_span_labels():
-    token_labels = [TokenLabel("Luke", 0, 4, "PER")]
+    #
+    token_labels = [TokenLabel(0, 4, "PER")]
     actual = token_labels_to_span_labels(token_labels)
-    assert actual == [SpanLabel("Luke", "PER", 0, 4)]
+    assert actual == [SpanLabel("PER", 0, 4)]
 
-    tokens = [Token("Luke", 0, 4), Token("Skywalker", 5, 14)]
-    tags = ["PER", "PER"]
-    actual = token_labels_to_span_labels(tokens, tags)
+    # text: Luke
+    token_labels = [
+        TokenLabel(0, 4, "PER"),
+        TokenLabel(5, 14, "PER"),
+    ]
+    actual = token_labels_to_span_labels(token_labels)
     assert actual == [SpanLabel("PER", 0, 14)]
 
-    tokens = [Token("Luke", 0, 4), Token("Skywalker", 5, 14), Token(".", 14, 15)]
-    tags = ["PER", "PER", "O"]
-    actual = token_labels_to_span_labels(tokens, tags)
+    # text: Luke Skywalker
+    token_labels = [
+        TokenLabel(0, 4, "PER"),
+        TokenLabel(5, 14, "PER"),
+        TokenLabel(14, 15, "O"),
+    ]
+    actual = token_labels_to_span_labels(token_labels)
     assert actual == [SpanLabel("PER", 0, 14), SpanLabel("O", 14, 15)]
 
-    tokens = [Token("Luke-", 0, 5), Token("Skywalker", 5, 14)]
-    tags = ["PER", "PER"]
-    actual = token_labels_to_span_labels(tokens, tags)
+    # text: Luke-Skywalker
+    token_labels = [TokenLabel(0, 5, "PER"), TokenLabel(5, 14, "PER")]
+    actual = token_labels_to_span_labels(token_labels)
     assert actual == [SpanLabel("PER", 0, 14)]
 
-    tokens = [
-        Token("one", 0, 3),
-        Token("day", 4, 7),
-        Token(",", 7, 8),
-        Token("Luke", 9, 13),
-        Token("Skywalker", 14, 23),
-        Token("and", 24, 27),
-        Token("Wedge", 28, 33),
-        Token("Antilles", 34, 42),
-        Token("recover", 43, 50),
-        Token("a", 51, 52),
-        Token("message", 53, 60),
+    # text: one day, Luke Skywalker and Wedge Antilles recover a message
+    token_labels = [
+        TokenLabel(0, 3, "O"),
+        TokenLabel(4, 7, "O"),
+        TokenLabel(7, 8, "O"),
+        TokenLabel(9, 13, "PER"),
+        TokenLabel(14, 23, "PER"),
+        TokenLabel(24, 27, "O"),
+        TokenLabel(28, 33, "PER"),
+        TokenLabel(34, 42, "PER"),
+        TokenLabel(43, 50, "O"),
+        TokenLabel(51, 52, "O"),
+        TokenLabel(53, 60, "O"),
     ]
-    tags = ["O", "O", "O", "PER", "PER", "O", "PER", "PER", "O", "O", "O"]
-    actual = token_labels_to_span_labels(tokens, tags)
+    actual = token_labels_to_span_labels(token_labels)
     assert actual == [
         SpanLabel("O", 0, 8),
         SpanLabel("PER", 9, 23),
@@ -78,9 +87,3 @@ def test_token_labels_to_span_labels():
         SpanLabel("PER", 28, 42),
         SpanLabel("O", 43, 60),
     ]
-
-    tokens = [Token(".", 0, 1)]
-    tags = ["O", "O"]
-    with pytest.raises(AssertionError) as err:
-        token_labels_to_span_labels(tokens, tags)
-    assert str(err.value) == "Length mismatch, where len(tokens)=1 and len(tags)=2"

--- a/pii_recognition/recognisers/crf_recogniser.py
+++ b/pii_recognition/recognisers/crf_recogniser.py
@@ -1,9 +1,9 @@
-from typing import List, Dict
+from typing import Dict, List
 
 from pycrfsuite import Tagger
 
 from pii_recognition.features.word_to_features import word2features
-from pii_recognition.labels.schema import SpanLabel
+from pii_recognition.labels.schema import SpanLabel, TokenLabel
 from pii_recognition.labels.span import token_labels_to_span_labels
 from pii_recognition.tokenisation import tokeniser_registry
 from pii_recognition.tokenisation.token_schema import Token
@@ -53,6 +53,14 @@ class CrfRecogniser(EntityRecogniser):
         entity_tags = self.model.tag(features)
 
         assert len(entity_tags) == len(tokens) == len(preprocessed_text)
+        token_labels = [
+            TokenLabel(
+                entity_type=entity_tags[i],
+                start=preprocessed_text[i].start,
+                end=preprocessed_text[i].end,
+            )
+            for i in range(len(entity_tags))
+        ]
 
-        spans = token_labels_to_span_labels(preprocessed_text, entity_tags)
+        spans = token_labels_to_span_labels(token_labels)
         return [span for span in spans if span.entity_type in entities]

--- a/pii_recognition/recognisers/first_letter_uppercase_recogniser.py
+++ b/pii_recognition/recognisers/first_letter_uppercase_recogniser.py
@@ -1,6 +1,6 @@
 from typing import Dict, List
 
-from pii_recognition.labels.schema import SpanLabel
+from pii_recognition.labels.schema import SpanLabel, TokenLabel
 from pii_recognition.labels.span import token_labels_to_span_labels
 from pii_recognition.tokenisation import tokeniser_registry
 
@@ -26,6 +26,14 @@ class FirstLetterUppercaseRecogniser(EntityRecogniser):
     def analyse(self, text: str, entities: List[str]) -> List[SpanLabel]:
         tokens = self._tokeniser.tokenise(text)
         entity_tags = [self.PER if token.text.istitle() else "O" for token in tokens]
+        assert len(tokens) == len(entity_tags)
 
-        spans = token_labels_to_span_labels(tokens, entity_tags)
+        token_labels = [
+            TokenLabel(
+                entity_type=entity_tags[i], start=tokens[i].start, end=tokens[i].end
+            )
+            for i in range(len(tokens))
+        ]
+
+        spans = token_labels_to_span_labels(token_labels)
         return [span for span in spans if span.entity_type in entities]

--- a/pii_recognition/tokenisation/token_schema.py
+++ b/pii_recognition/tokenisation/token_schema.py
@@ -3,6 +3,5 @@ from dataclasses import dataclass
 
 @dataclass
 class Token:
-    text: str
     start: int
     end: int

--- a/pii_recognition/tokenisation/token_schema.py
+++ b/pii_recognition/tokenisation/token_schema.py
@@ -5,5 +5,6 @@ from dataclasses import dataclass
 class Token:
     # text is not included on purpose, otherwise it would make
     # conversion between SpanLabel and TokenLabel difficult
+    text: str
     start: int
     end: int

--- a/pii_recognition/tokenisation/token_schema.py
+++ b/pii_recognition/tokenisation/token_schema.py
@@ -3,5 +3,7 @@ from dataclasses import dataclass
 
 @dataclass
 class Token:
+    # text is not included on purpose, otherwise it would make
+    # conversion between SpanLabel and TokenLabel difficult
     start: int
     end: int

--- a/pii_recognition/tokenisation/token_schema.py
+++ b/pii_recognition/tokenisation/token_schema.py
@@ -3,8 +3,6 @@ from dataclasses import dataclass
 
 @dataclass
 class Token:
-    # text is not included on purpose, otherwise it would make
-    # conversion between SpanLabel and TokenLabel difficult
     text: str
     start: int
     end: int

--- a/pii_recognition/utils.py
+++ b/pii_recognition/utils.py
@@ -1,6 +1,7 @@
-from typing import Any, Iterable, Optional, Type
+from typing import Any, Iterable, Optional, Sequence, Type
 
 
+# TODO: add test
 def write_iterable_to_text(iterable: Iterable, file_path: str):
     with open(file_path, "w") as f:
         for elem in iterable:
@@ -22,3 +23,8 @@ class cached_property(property):  # class name follows the convention of propert
             value = self.fget(obj)  # type: ignore
             obj.__dict__[name] = value  # saving back to object
             return value
+
+
+# TODO: add test
+def is_ascending(sequence: Sequence) -> bool:
+    return all(sequence[i] < sequence[i + 1] for i in range(len(sequence) - 1))

--- a/pii_recognition/utils.py
+++ b/pii_recognition/utils.py
@@ -25,6 +25,5 @@ class cached_property(property):  # class name follows the convention of propert
             return value
 
 
-# TODO: add test
 def is_ascending(sequence: Sequence) -> bool:
     return all(sequence[i] < sequence[i + 1] for i in range(len(sequence) - 1))

--- a/pii_recognition/utils_test.py
+++ b/pii_recognition/utils_test.py
@@ -1,5 +1,6 @@
-from pii_recognition.utils import cached_property
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
+
+from pii_recognition.utils import cached_property, is_ascending
 
 
 def test_cached_property():
@@ -23,3 +24,17 @@ def test_cached_property():
         actual.a
         actual.a
         mock_fget.assert_called_once()
+
+
+def test_is_ascending():
+    actual = is_ascending([1, 2, 3])
+    assert actual is True
+
+    actual = is_ascending([3, 2, 1])
+    assert actual is False
+
+    actual = is_ascending((1, 2, 3))
+    assert actual is True
+
+    actual = is_ascending(range(5))
+    assert actual is True


### PR DESCRIPTION
### Description
Create a dataclass container for `TokenLabel`. This will ease the conversion between `SpanLabel` and `TokenLabel` in evaluation.

### Context
In the old implementation, two arguments are needed `Token` and `tags` (labels) when performing the conversion. Now these information gets encapsulated in one place -- `TokenLabel`. This simplifies the function call.

#### Checklist
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.