### PR TITLE
Refactor evaluator on inputing tokeniser object

### DIFF
--- a/pii_recognition/evaluation/model_evaluator.py
+++ b/pii_recognition/evaluation/model_evaluator.py
@@ -7,7 +7,6 @@ from pii_recognition.labels.mapping import map_labels, mask_labels
 from pii_recognition.labels.schema import EvalLabel, SpanLabel, TokenLabel
 from pii_recognition.labels.span import span_labels_to_token_labels
 from pii_recognition.recognisers.entity_recogniser import EntityRecogniser
-from pii_recognition.tokenisation import tokeniser_registry
 from pii_recognition.tokenisation.tokenisers import Tokeniser
 
 from .metrics import compute_f_beta

--- a/pii_recognition/evaluation/model_evaluator.py
+++ b/pii_recognition/evaluation/model_evaluator.py
@@ -31,7 +31,7 @@ class ModelEvaluator:
         self,
         recogniser: EntityRecogniser,
         tokeniser: Tokeniser,
-        target_entities: List[str],
+        target_entities: List[str],  # TODO: rename
         convert_labels: Optional[Dict[str, str]] = None,
     ):
         self.recogniser = recogniser

--- a/pii_recognition/evaluation/model_evaluator.py
+++ b/pii_recognition/evaluation/model_evaluator.py
@@ -35,7 +35,7 @@ class ModelEvaluator:
         convert_labels: Optional[Dict[str, str]] = None,
     ):
         self.recogniser = recogniser
-        self._tokeniser = tokeniser
+        self.tokeniser = tokeniser
         self._convert_labels = convert_labels
         self.target_entities = target_entities
         if self._convert_labels:
@@ -62,7 +62,7 @@ class ModelEvaluator:
 
     def get_token_based_prediction(self, text: str) -> List[TokenLabel]:
         recognised_entities = self.get_span_based_prediction(text)
-        tokens = self._tokeniser.tokenise(text)
+        tokens = self.tokeniser.tokenise(text)
         token_labels = span_labels_to_token_labels(recognised_entities, tokens)
 
         # validate predictions
@@ -90,7 +90,7 @@ class ModelEvaluator:
             )
 
         sample_error = SampleError(token_errors=[], full_text=text, failed=False)
-        tokens = self._tokeniser.tokenise(text)
+        tokens = self.tokeniser.tokenise(text)
 
         for i in range(len(annotations)):
             label_pair_counter[EvalLabel(annotations[i], predictions[i])] += 1

--- a/pii_recognition/evaluation/model_evaluator_test.py
+++ b/pii_recognition/evaluation/model_evaluator_test.py
@@ -12,9 +12,9 @@ from .model_evaluator import ModelEvaluator, tokeniser_registry
 from .prediction_error import SampleError, TokenError
 
 
-@fixture
-def text():
-    return "This is Bob from Melbourne."
+# @fixture
+# def text():
+#     return "This is Bob from Melbourne."
 
 
 @fixture
@@ -25,11 +25,6 @@ def mock_recogniser():
         SpanLabel("LOC", 17, 26),
     ]
     return recogniser
-
-
-@fixture
-def tokeniser_config():
-    return {"name": "fake_tokeniser", "config": {"fake_param": "fake_value"}}
 
 
 def get_mock_tokeniser():
@@ -46,280 +41,277 @@ def get_mock_tokeniser():
     return tokeniser
 
 
-@patch.object(
-    target=tokeniser_registry,
-    attribute="create_instance",
-    new_callable=get_mock_tokeniser,
-)
-def test_class_init(mock_tokeniser, tokeniser_config):
+def test_class_init():
     mock_recogniser = Mock()
+    mock_tokeniser = Mock()
 
     evaluator = ModelEvaluator(
         recogniser=mock_recogniser,
+        tokeniser=mock_tokeniser,
         target_entities=["PER", "LOC"],
-        tokeniser=tokeniser_config,
-        convert_labels={"PER": "PERSON"},
+        convert_labels={"PER": "PERSON", "LOC": "LOCATION"},
     )
 
     assert evaluator.recogniser == mock_recogniser
+    assert evaluator.tokeniser == mock_tokeniser
     assert evaluator.target_entities == ["PER", "LOC"]
-    mock_tokeniser.assert_called_with("fake_tokeniser", {"fake_param": "fake_value"})
-    assert evaluator._convert_labels == {"PER": "PERSON"}
+    assert evaluator._convert_labels == {"PER": "PERSON", "LOC": "LOCATION"}
+    assert evaluator._translated_target_entities == ["PERSON", "LOCATION"]
 
 
-@patch.object(
-    target=tokeniser_registry,
-    attribute="create_instance",
-    new_callable=get_mock_tokeniser,
-)
-def test_get_token_based_prediction(
-    mock_tokeniser, text, mock_recogniser, tokeniser_config
-):
-    # test 1: succeed
-    evaluator = ModelEvaluator(
-        recogniser=mock_recogniser,
-        target_entities=["PER", "LOC"],
-        tokeniser=tokeniser_config,
-    )
-    actual = evaluator.get_token_based_prediction(text)
-    assert [x.entity_type for x in actual] == ["O", "O", "PER", "O", "LOC", "O"]
+# @patch.object(
+#     target=tokeniser_registry,
+#     attribute="create_instance",
+#     new_callable=get_mock_tokeniser,
+# )
+# def test_get_token_based_prediction(
+#     mock_tokeniser, text, mock_recogniser, tokeniser_config
+# ):
+#     # test 1: succeed
+#     evaluator = ModelEvaluator(
+#         recogniser=mock_recogniser,
+#         target_entities=["PER", "LOC"],
+#         tokeniser=tokeniser_config,
+#     )
+#     actual = evaluator.get_token_based_prediction(text)
+#     assert [x.entity_type for x in actual] == ["O", "O", "PER", "O", "LOC", "O"]
 
-    # test 2: raise assertion error
-    evaluator = ModelEvaluator(
-        recogniser=mock_recogniser, target_entities=["PER"], tokeniser=tokeniser_config,
-    )
-    with pytest.raises(AssertionError) as err:
-        evaluator.get_token_based_prediction(text)
-    assert str(err.value) == f"Predictions contain unasked entities ['LOC']"
-
-
-@patch.object(
-    target=tokeniser_registry,
-    attribute="create_instance",
-    new_callable=get_mock_tokeniser,
-)
-def test__compare_predicted_and_truth(mock_tokeniser, text, tokeniser_config):
-    # test 1: predicted == truths
-    evaluator = ModelEvaluator(
-        recogniser=Mock(), target_entities=["ANY"], tokeniser=tokeniser_config,
-    )
-    counter, mistakes = evaluator._compare_predicted_and_truth(
-        text,
-        annotations=["O", "O", "PER", "O", "LOC", "O"],
-        predictions=["O", "O", "PER", "O", "LOC", "O"],
-    )
-    assert counter == Counter(
-        {EvalLabel("O", "O"): 4, EvalLabel("LOC", "LOC"): 1, EvalLabel("PER", "PER"): 1}
-    )
-    assert mistakes == SampleError(token_errors=[], full_text=text, failed=False)
-
-    # test 2: predicted != truths where 2 mistakes were made
-    evaluator = ModelEvaluator(
-        recogniser=Mock(), target_entities=["ANY"], tokeniser=tokeniser_config,
-    )
-    counter, mistakes = evaluator._compare_predicted_and_truth(
-        text,
-        annotations=["O", "O", "PER", "O", "LOC", "O"],
-        predictions=["LOC", "O", "PER", "O", "O", "O"],
-    )
-    assert counter == Counter(
-        {
-            EvalLabel("O", "O"): 3,
-            EvalLabel("O", "LOC"): 1,
-            EvalLabel("LOC", "O"): 1,
-            EvalLabel("PER", "PER"): 1,
-        }
-    )
-    assert mistakes == SampleError(
-        token_errors=[
-            TokenError("O", "LOC", "This"),
-            TokenError("LOC", "O", "Melbourne"),
-        ],
-        full_text=text,
-        failed=False,
-    )
-
-    # test 3: len(predicted) != len(truths)
-    evaluator = ModelEvaluator(
-        recogniser=Mock(), target_entities=["ANY"], tokeniser=tokeniser_config
-    )
-    counter, mistakes = evaluator._compare_predicted_and_truth(
-        text,
-        annotations=["O", "O", "PER", "O", "LOC", "O"],
-        predictions=["LOC", "O", "PER", "O", "O"],
-    )
-    assert counter == Counter()
-    assert mistakes == SampleError(token_errors=[], full_text=text, failed=True)
-
-    # test 4: entity mapping
-    evaluator = ModelEvaluator(
-        recogniser=Mock(),
-        target_entities=["ANY"],
-        tokeniser=tokeniser_config,
-        convert_labels={"LOC": "LOCATION", "PER": "PERSON"},
-    )
-    counter, mistakes = evaluator._compare_predicted_and_truth(
-        text,
-        annotations=["O", "O", "PERSON", "O", "LOCATION", "O"],
-        predictions=["O", "O", "PER", "O", "LOC", "O"],
-    )
-    assert counter == Counter(
-        {
-            EvalLabel("O", "O"): 4,
-            EvalLabel("PERSON", "PERSON"): 1,
-            EvalLabel("LOCATION", "LOCATION"): 1,
-        }
-    )
-    assert mistakes == SampleError(token_errors=[], full_text=text, failed=False)
+#     # test 2: raise assertion error
+#     evaluator = ModelEvaluator(
+#         recogniser=mock_recogniser, target_entities=["PER"], tokeniser=tokeniser_config,
+#     )
+#     with pytest.raises(AssertionError) as err:
+#         evaluator.get_token_based_prediction(text)
+#     assert str(err.value) == f"Predictions contain unasked entities ['LOC']"
 
 
-@patch.object(
-    target=tokeniser_registry,
-    attribute="create_instance",
-    new_callable=get_mock_tokeniser,
-)
-def test_evaluate_sample(mock_tokeniser, text, mock_recogniser, tokeniser_config):
-    evaluator = ModelEvaluator(
-        recogniser=mock_recogniser,
-        target_entities=["PER", "LOC"],
-        tokeniser=tokeniser_config,
-    )
+# @patch.object(
+#     target=tokeniser_registry,
+#     attribute="create_instance",
+#     new_callable=get_mock_tokeniser,
+# )
+# def test__compare_predicted_and_truth(mock_tokeniser, text, tokeniser_config):
+#     # test 1: predicted == truths
+#     evaluator = ModelEvaluator(
+#         recogniser=Mock(), target_entities=["ANY"], tokeniser=tokeniser_config,
+#     )
+#     counter, mistakes = evaluator._compare_predicted_and_truth(
+#         text,
+#         annotations=["O", "O", "PER", "O", "LOC", "O"],
+#         predictions=["O", "O", "PER", "O", "LOC", "O"],
+#     )
+#     assert counter == Counter(
+#         {EvalLabel("O", "O"): 4, EvalLabel("LOC", "LOC"): 1, EvalLabel("PER", "PER"): 1}
+#     )
+#     assert mistakes == SampleError(token_errors=[], full_text=text, failed=False)
 
-    # test 1: simple straightforward pass
-    counter, mistakes = evaluator.evaluate_sample(
-        text, annotations=["O", "O", "PER", "O", "LOC", "O"]
-    )
-    assert counter == Counter(
-        {EvalLabel("O", "O"): 4, EvalLabel("LOC", "LOC"): 1, EvalLabel("PER", "PER"): 1}
-    )
-    assert mistakes == SampleError(token_errors=[], full_text=text, failed=False)
+#     # test 2: predicted != truths where 2 mistakes were made
+#     evaluator = ModelEvaluator(
+#         recogniser=Mock(), target_entities=["ANY"], tokeniser=tokeniser_config,
+#     )
+#     counter, mistakes = evaluator._compare_predicted_and_truth(
+#         text,
+#         annotations=["O", "O", "PER", "O", "LOC", "O"],
+#         predictions=["LOC", "O", "PER", "O", "O", "O"],
+#     )
+#     assert counter == Counter(
+#         {
+#             EvalLabel("O", "O"): 3,
+#             EvalLabel("O", "LOC"): 1,
+#             EvalLabel("LOC", "O"): 1,
+#             EvalLabel("PER", "PER"): 1,
+#         }
+#     )
+#     assert mistakes == SampleError(
+#         token_errors=[
+#             TokenError("O", "LOC", "This"),
+#             TokenError("LOC", "O", "Melbourne"),
+#         ],
+#         full_text=text,
+#         failed=False,
+#     )
 
-    # test 2: annotated labels not in target_entities
-    counter, mistakes = evaluator.evaluate_sample(
-        text, annotations=["O", "MISC", "PER", "O", "LOC", "MISC"]
-    )
-    assert counter == Counter(
-        {EvalLabel("O", "O"): 4, EvalLabel("LOC", "LOC"): 1, EvalLabel("PER", "PER"): 1}
-    )
-    assert mistakes == SampleError(token_errors=[], full_text=text, failed=False)
+#     # test 3: len(predicted) != len(truths)
+#     evaluator = ModelEvaluator(
+#         recogniser=Mock(), target_entities=["ANY"], tokeniser=tokeniser_config
+#     )
+#     counter, mistakes = evaluator._compare_predicted_and_truth(
+#         text,
+#         annotations=["O", "O", "PER", "O", "LOC", "O"],
+#         predictions=["LOC", "O", "PER", "O", "O"],
+#     )
+#     assert counter == Counter()
+#     assert mistakes == SampleError(token_errors=[], full_text=text, failed=True)
 
-
-@patch.object(
-    target=tokeniser_registry,
-    attribute="create_instance",
-    new_callable=get_mock_tokeniser,
-)
-def test_evaluate_sample_with_label_conversion(
-    mock_tokeniser, mock_recogniser, tokeniser_config
-):
-    evaluator = ModelEvaluator(
-        recogniser=mock_recogniser,
-        target_entities=["PER", "LOC"],
-        tokeniser=tokeniser_config,
-        convert_labels={"PER": "I-PER", "LOC": "I-LOC"},
-    )
-    counter, mistakes = evaluator.evaluate_sample(
-        text, annotations=["O", "I-MISC", "I-PER", "O", "I-LOC", "I-MISC"]
-    )
-    assert counter == Counter(
-        {
-            EvalLabel("O", "O"): 4,
-            EvalLabel("I-LOC", "I-LOC"): 1,
-            EvalLabel("I-PER", "I-PER"): 1,
-        }
-    )
-    assert mistakes == SampleError(token_errors=[], full_text=text, failed=False)
-
-
-@patch.object(
-    target=tokeniser_registry,
-    attribute="create_instance",
-    new_callable=get_mock_tokeniser,
-)
-def test_evaulate_all(mock_tokeniser, text, mock_recogniser, tokeniser_config):
-    evaluator = ModelEvaluator(
-        recogniser=mock_recogniser,
-        target_entities=["PER", "LOC"],
-        tokeniser=tokeniser_config,
-    )
-    counters, mistakes = evaluator.evaulate_all(
-        texts=[text] * 2, annotations=[["O", "O", "PER", "O", "LOC", "O"]] * 2
-    )
-
-    assert (
-        counters
-        == [
-            Counter(
-                {
-                    EvalLabel("O", "O"): 4,
-                    EvalLabel("LOC", "LOC"): 1,
-                    EvalLabel("PER", "PER"): 1,
-                }
-            )
-        ]
-        * 2
-    )
-    assert mistakes == [SampleError(token_errors=[], full_text=text, failed=False)] * 2
+#     # test 4: entity mapping
+#     evaluator = ModelEvaluator(
+#         recogniser=Mock(),
+#         target_entities=["ANY"],
+#         tokeniser=tokeniser_config,
+#         convert_labels={"LOC": "LOCATION", "PER": "PERSON"},
+#     )
+#     counter, mistakes = evaluator._compare_predicted_and_truth(
+#         text,
+#         annotations=["O", "O", "PERSON", "O", "LOCATION", "O"],
+#         predictions=["O", "O", "PER", "O", "LOC", "O"],
+#     )
+#     assert counter == Counter(
+#         {
+#             EvalLabel("O", "O"): 4,
+#             EvalLabel("PERSON", "PERSON"): 1,
+#             EvalLabel("LOCATION", "LOCATION"): 1,
+#         }
+#     )
+#     assert mistakes == SampleError(token_errors=[], full_text=text, failed=False)
 
 
-@patch.object(
-    target=tokeniser_registry,
-    attribute="create_instance",
-    new_callable=get_mock_tokeniser,
-)
-def test_calculate_score(mock_tokeniser, tokeniser_config):
-    evaluator = ModelEvaluator(
-        recogniser=Mock(), target_entities=["PER", "LOC"], tokeniser=tokeniser_config
-    )
+# @patch.object(
+#     target=tokeniser_registry,
+#     attribute="create_instance",
+#     new_callable=get_mock_tokeniser,
+# )
+# def test_evaluate_sample(mock_tokeniser, text, mock_recogniser, tokeniser_config):
+#     evaluator = ModelEvaluator(
+#         recogniser=mock_recogniser,
+#         target_entities=["PER", "LOC"],
+#         tokeniser=tokeniser_config,
+#     )
 
-    # test 1: LOC 0.=presion=recall
-    counters = [
-        Counter(
-            {
-                EvalLabel("O", "O"): 3,
-                EvalLabel("O", "LOC"): 1,
-                EvalLabel("LOC", "O"): 1,
-                EvalLabel("PER", "PER"): 1,
-            }
-        )
-    ]
-    recall, precision, f1 = evaluator.calculate_score(counters)
-    assert recall == {"PER": 1.0, "LOC": 0.0}
-    assert precision == {"PER": 1.0, "LOC": 0.0}
-    assert f1 == {"PER": 1.0, "LOC": np.nan}
+#     # test 1: simple straightforward pass
+#     counter, mistakes = evaluator.evaluate_sample(
+#         text, annotations=["O", "O", "PER", "O", "LOC", "O"]
+#     )
+#     assert counter == Counter(
+#         {EvalLabel("O", "O"): 4, EvalLabel("LOC", "LOC"): 1, EvalLabel("PER", "PER"): 1}
+#     )
+#     assert mistakes == SampleError(token_errors=[], full_text=text, failed=False)
 
-    # test 2: multiple texts
-    counters = [
-        Counter(
-            {
-                EvalLabel("O", "O"): 4,
-                EvalLabel("LOC", "LOC"): 1,
-                EvalLabel("PER", "PER"): 1,
-            }
-        )
-    ] * 2
-    recall, precision, f1 = evaluator.calculate_score(counters)
-    assert recall == {"PER": 1.0, "LOC": 1.0}
-    assert precision == {"PER": 1.0, "LOC": 1.0}
-    assert f1 == {"PER": 1.0, "LOC": 1.0}
+#     # test 2: annotated labels not in target_entities
+#     counter, mistakes = evaluator.evaluate_sample(
+#         text, annotations=["O", "MISC", "PER", "O", "LOC", "MISC"]
+#     )
+#     assert counter == Counter(
+#         {EvalLabel("O", "O"): 4, EvalLabel("LOC", "LOC"): 1, EvalLabel("PER", "PER"): 1}
+#     )
+#     assert mistakes == SampleError(token_errors=[], full_text=text, failed=False)
 
-    # test 3: with entity mapping
-    evaluator = ModelEvaluator(
-        recogniser=Mock(),
-        target_entities=["PER", "LOC"],
-        tokeniser=tokeniser_config,
-        convert_labels={"LOC": "LOCATION", "PER": "PERSON"},
-    )
-    counters = [
-        Counter(
-            {
-                EvalLabel("O", "O"): 4,
-                EvalLabel("LOCATION", "LOCATION"): 1,
-                EvalLabel("PERSON", "PERSON"): 1,
-            }
-        )
-    ] * 2
-    recall, precision, f1 = evaluator.calculate_score(counters)
-    assert recall == {"PERSON": 1.0, "LOCATION": 1.0}
-    assert precision == {"PERSON": 1.0, "LOCATION": 1.0}
-    assert f1 == {"PERSON": 1.0, "LOCATION": 1.0}
+
+# @patch.object(
+#     target=tokeniser_registry,
+#     attribute="create_instance",
+#     new_callable=get_mock_tokeniser,
+# )
+# def test_evaluate_sample_with_label_conversion(
+#     mock_tokeniser, mock_recogniser, tokeniser_config
+# ):
+#     evaluator = ModelEvaluator(
+#         recogniser=mock_recogniser,
+#         target_entities=["PER", "LOC"],
+#         tokeniser=tokeniser_config,
+#         convert_labels={"PER": "I-PER", "LOC": "I-LOC"},
+#     )
+#     counter, mistakes = evaluator.evaluate_sample(
+#         text, annotations=["O", "I-MISC", "I-PER", "O", "I-LOC", "I-MISC"]
+#     )
+#     assert counter == Counter(
+#         {
+#             EvalLabel("O", "O"): 4,
+#             EvalLabel("I-LOC", "I-LOC"): 1,
+#             EvalLabel("I-PER", "I-PER"): 1,
+#         }
+#     )
+#     assert mistakes == SampleError(token_errors=[], full_text=text, failed=False)
+
+
+# @patch.object(
+#     target=tokeniser_registry,
+#     attribute="create_instance",
+#     new_callable=get_mock_tokeniser,
+# )
+# def test_evaulate_all(mock_tokeniser, text, mock_recogniser, tokeniser_config):
+#     evaluator = ModelEvaluator(
+#         recogniser=mock_recogniser,
+#         target_entities=["PER", "LOC"],
+#         tokeniser=tokeniser_config,
+#     )
+#     counters, mistakes = evaluator.evaulate_all(
+#         texts=[text] * 2, annotations=[["O", "O", "PER", "O", "LOC", "O"]] * 2
+#     )
+
+#     assert (
+#         counters
+#         == [
+#             Counter(
+#                 {
+#                     EvalLabel("O", "O"): 4,
+#                     EvalLabel("LOC", "LOC"): 1,
+#                     EvalLabel("PER", "PER"): 1,
+#                 }
+#             )
+#         ]
+#         * 2
+#     )
+#     assert mistakes == [SampleError(token_errors=[], full_text=text, failed=False)] * 2
+
+
+# @patch.object(
+#     target=tokeniser_registry,
+#     attribute="create_instance",
+#     new_callable=get_mock_tokeniser,
+# )
+# def test_calculate_score(mock_tokeniser, tokeniser_config):
+#     evaluator = ModelEvaluator(
+#         recogniser=Mock(), target_entities=["PER", "LOC"], tokeniser=tokeniser_config
+#     )
+
+#     # test 1: LOC 0.=presion=recall
+#     counters = [
+#         Counter(
+#             {
+#                 EvalLabel("O", "O"): 3,
+#                 EvalLabel("O", "LOC"): 1,
+#                 EvalLabel("LOC", "O"): 1,
+#                 EvalLabel("PER", "PER"): 1,
+#             }
+#         )
+#     ]
+#     recall, precision, f1 = evaluator.calculate_score(counters)
+#     assert recall == {"PER": 1.0, "LOC": 0.0}
+#     assert precision == {"PER": 1.0, "LOC": 0.0}
+#     assert f1 == {"PER": 1.0, "LOC": np.nan}
+
+#     # test 2: multiple texts
+#     counters = [
+#         Counter(
+#             {
+#                 EvalLabel("O", "O"): 4,
+#                 EvalLabel("LOC", "LOC"): 1,
+#                 EvalLabel("PER", "PER"): 1,
+#             }
+#         )
+#     ] * 2
+#     recall, precision, f1 = evaluator.calculate_score(counters)
+#     assert recall == {"PER": 1.0, "LOC": 1.0}
+#     assert precision == {"PER": 1.0, "LOC": 1.0}
+#     assert f1 == {"PER": 1.0, "LOC": 1.0}
+
+#     # test 3: with entity mapping
+#     evaluator = ModelEvaluator(
+#         recogniser=Mock(),
+#         target_entities=["PER", "LOC"],
+#         tokeniser=tokeniser_config,
+#         convert_labels={"LOC": "LOCATION", "PER": "PERSON"},
+#     )
+#     counters = [
+#         Counter(
+#             {
+#                 EvalLabel("O", "O"): 4,
+#                 EvalLabel("LOCATION", "LOCATION"): 1,
+#                 EvalLabel("PERSON", "PERSON"): 1,
+#             }
+#         )
+#     ] * 2
+#     recall, precision, f1 = evaluator.calculate_score(counters)
+#     assert recall == {"PERSON": 1.0, "LOCATION": 1.0}
+#     assert precision == {"PERSON": 1.0, "LOCATION": 1.0}
+#     assert f1 == {"PERSON": 1.0, "LOCATION": 1.0}

--- a/pii_recognition/evaluation/model_evaluator_test.py
+++ b/pii_recognition/evaluation/model_evaluator_test.py
@@ -74,6 +74,30 @@ def test_class_init():
     assert evaluator._translated_entities == ["PERSON", "LOCATION"]
 
 
+def test_get_span_based_prediction(mock_recogniser, mock_tokeniser, text):
+    # test 1: succeed
+    evaluator = ModelEvaluator(
+        recogniser=mock_recogniser,
+        tokeniser=mock_tokeniser,
+        target_recogniser_entities=["PER", "LOC"],
+    )
+    actual = evaluator.get_span_based_prediction(text)
+    assert actual == [
+        SpanLabel(entity_type="PER", start=8, end=11),
+        SpanLabel(entity_type="LOC", start=17, end=26),
+    ]
+
+    # test 2: raise assertion error
+    evaluator = ModelEvaluator(
+        recogniser=mock_recogniser,
+        tokeniser=mock_tokeniser,
+        target_recogniser_entities=["PER"],
+    )
+    with pytest.raises(AssertionError) as err:
+        evaluator.get_span_based_prediction(text)
+    assert str(err.value) == f"Predictions contain unasked entities ['LOC']"
+
+
 def test_get_token_based_prediction(mock_recogniser, mock_tokeniser, text):
     # test 1: succeed
     evaluator = ModelEvaluator(

--- a/pii_recognition/evaluation/model_evaluator_test.py
+++ b/pii_recognition/evaluation/model_evaluator_test.py
@@ -63,15 +63,15 @@ def test_class_init():
     evaluator = ModelEvaluator(
         recogniser=mock_recogniser,
         tokeniser=mock_tokeniser,
-        target_entities=["PER", "LOC"],
+        target_recogniser_entities=["PER", "LOC"],
         convert_labels={"PER": "PERSON", "LOC": "LOCATION"},
     )
 
     assert evaluator.recogniser == mock_recogniser
     assert evaluator.tokeniser == mock_tokeniser
-    assert evaluator.target_entities == ["PER", "LOC"]
+    assert evaluator.target_recogniser_entities == ["PER", "LOC"]
     assert evaluator._convert_labels == {"PER": "PERSON", "LOC": "LOCATION"}
-    assert evaluator._translated_target_entities == ["PERSON", "LOCATION"]
+    assert evaluator._translated_entities == ["PERSON", "LOCATION"]
 
 
 def test_get_token_based_prediction(mock_recogniser, mock_tokeniser, text):
@@ -79,14 +79,14 @@ def test_get_token_based_prediction(mock_recogniser, mock_tokeniser, text):
     evaluator = ModelEvaluator(
         recogniser=mock_recogniser,
         tokeniser=mock_tokeniser,
-        target_entities=["PER", "LOC"],
+        target_recogniser_entities=["PER", "LOC"],
     )
     actual = evaluator.get_token_based_prediction(text)
     assert [x.entity_type for x in actual] == ["O", "O", "PER", "O", "LOC", "O"]
 
     # test 2: raise assertion error
     evaluator = ModelEvaluator(
-        recogniser=mock_recogniser, tokeniser=mock_tokeniser, target_entities=["PER"],
+        recogniser=mock_recogniser, tokeniser=mock_tokeniser, target_recogniser_entities=["PER"],
     )
     with pytest.raises(AssertionError) as err:
         evaluator.get_token_based_prediction(text)
@@ -94,9 +94,9 @@ def test_get_token_based_prediction(mock_recogniser, mock_tokeniser, text):
 
 
 def test__compare_predicted_and_truth(text):
-    # target_entities does not matter for this test
+    # target_recogniser_entities does not matter for this test
     evaluator = ModelEvaluator(
-        recogniser=Mock(), tokeniser=Mock(), target_entities=["ANY"]
+        recogniser=Mock(), tokeniser=Mock(), target_recogniser_entities=["ANY"]
     )
 
     # test 1: predicted == truths
@@ -149,7 +149,7 @@ def test__compare_predicted_and_truth(text):
     evaluator = ModelEvaluator(
         recogniser=Mock(),
         tokeniser=Mock(),
-        target_entities=["ANY"],
+        target_recogniser_entities=["ANY"],
         convert_labels={"LOC": "LOCATION", "PER": "PERSON"},
     )
     counter, mistakes = evaluator._compare_predicted_and_truth(
@@ -172,7 +172,7 @@ def test_evaluate_sample_no_label_conversion(text, mock_recogniser, mock_tokenis
     evaluator = ModelEvaluator(
         recogniser=mock_recogniser,
         tokeniser=mock_tokeniser,
-        target_entities=["PER", "LOC"],
+        target_recogniser_entities=["PER", "LOC"],
     )
 
     # test 1: simple straightforward and pass
@@ -184,7 +184,7 @@ def test_evaluate_sample_no_label_conversion(text, mock_recogniser, mock_tokenis
     )
     assert mistakes == SampleError(token_errors=[], full_text=text, failed=False)
 
-    # test 2: annotated labels not in target_entities
+    # test 2: annotated labels not in target_recogniser_entities
     counter, mistakes = evaluator.evaluate_sample(
         text, annotations=["O", "MISC", "PER", "O", "LOC", "MISC"]
     )
@@ -204,7 +204,7 @@ def test_evaluate_sample_no_label_conversion(text, mock_recogniser, mock_tokenis
 
     # test 4: recogniser predicted on ["PER", "LOC"] but only asking for ["PER"]
     evaluator = ModelEvaluator(
-        recogniser=mock_recogniser, tokeniser=mock_tokeniser, target_entities=["PER"],
+        recogniser=mock_recogniser, tokeniser=mock_tokeniser, target_recogniser_entities=["PER"],
     )
     with pytest.raises(AssertionError) as err:
         counter, mistakes = evaluator.evaluate_sample(
@@ -217,7 +217,7 @@ def test_evaluate_sample_with_label_conversion(text, mock_recogniser, mock_token
     evaluator = ModelEvaluator(
         recogniser=mock_recogniser,
         tokeniser=mock_tokeniser,
-        target_entities=["PER", "LOC"],
+        target_recogniser_entities=["PER", "LOC"],
         convert_labels={"PER": "I-PER", "LOC": "I-LOC"},
     )
     counter, mistakes = evaluator.evaluate_sample(
@@ -237,7 +237,7 @@ def test_evaluate_sample_with_mistakes(text, mock_bad_recogniser, mock_tokeniser
     evaluator = ModelEvaluator(
         recogniser=mock_bad_recogniser,
         tokeniser=mock_tokeniser,
-        target_entities=["PER", "LOC"],
+        target_recogniser_entities=["PER", "LOC"],
         convert_labels={"PER": "I-PER", "LOC": "I-LOC"},
     )
     counter, mistakes = evaluator.evaluate_sample(
@@ -254,7 +254,7 @@ def test_evaulate_all(text, mock_recogniser, mock_tokeniser):
     evaluator = ModelEvaluator(
         recogniser=mock_recogniser,
         tokeniser=mock_tokeniser,
-        target_entities=["PER", "LOC"],
+        target_recogniser_entities=["PER", "LOC"],
     )
     counters, mistakes = evaluator.evaulate_all(
         texts=[text] * 2, annotations=[["O", "O", "PER", "O", "LOC", "O"]] * 2
@@ -278,7 +278,7 @@ def test_evaulate_all(text, mock_recogniser, mock_tokeniser):
 
 def test_calculate_score(mock_tokeniser):
     evaluator = ModelEvaluator(
-        recogniser=Mock(), tokeniser=mock_tokeniser, target_entities=["PER", "LOC"],
+        recogniser=Mock(), tokeniser=mock_tokeniser, target_recogniser_entities=["PER", "LOC"],
     )
 
     # test 1: LOC 0.=presion=recall
@@ -316,7 +316,7 @@ def test_calculate_score(mock_tokeniser):
     evaluator = ModelEvaluator(
         recogniser=Mock(),
         tokeniser=mock_tokeniser,
-        target_entities=["PER", "LOC"],
+        target_recogniser_entities=["PER", "LOC"],
         convert_labels={"LOC": "LOCATION", "PER": "PERSON"},
     )
     counters = [

--- a/pii_recognition/evaluation/model_evaluator_test.py
+++ b/pii_recognition/evaluation/model_evaluator_test.py
@@ -1,6 +1,6 @@
 from collections import Counter
 from typing import List
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import numpy as np
 import pytest
@@ -9,7 +9,7 @@ from pytest import fixture
 from pii_recognition.labels.schema import EvalLabel, SpanLabel
 from pii_recognition.tokenisation.token_schema import Token
 
-from .model_evaluator import ModelEvaluator, tokeniser_registry
+from .model_evaluator import ModelEvaluator
 from .prediction_error import SampleError, TokenError
 
 
@@ -86,7 +86,9 @@ def test_get_token_based_prediction(mock_recogniser, mock_tokeniser, text):
 
     # test 2: raise assertion error
     evaluator = ModelEvaluator(
-        recogniser=mock_recogniser, tokeniser=mock_tokeniser, target_recogniser_entities=["PER"],
+        recogniser=mock_recogniser,
+        tokeniser=mock_tokeniser,
+        target_recogniser_entities=["PER"],
     )
     with pytest.raises(AssertionError) as err:
         evaluator.get_token_based_prediction(text)
@@ -204,7 +206,9 @@ def test_evaluate_sample_no_label_conversion(text, mock_recogniser, mock_tokenis
 
     # test 4: recogniser predicted on ["PER", "LOC"] but only asking for ["PER"]
     evaluator = ModelEvaluator(
-        recogniser=mock_recogniser, tokeniser=mock_tokeniser, target_recogniser_entities=["PER"],
+        recogniser=mock_recogniser,
+        tokeniser=mock_tokeniser,
+        target_recogniser_entities=["PER"],
     )
     with pytest.raises(AssertionError) as err:
         counter, mistakes = evaluator.evaluate_sample(
@@ -278,7 +282,9 @@ def test_evaulate_all(text, mock_recogniser, mock_tokeniser):
 
 def test_calculate_score(mock_tokeniser):
     evaluator = ModelEvaluator(
-        recogniser=Mock(), tokeniser=mock_tokeniser, target_recogniser_entities=["PER", "LOC"],
+        recogniser=Mock(),
+        tokeniser=mock_tokeniser,
+        target_recogniser_entities=["PER", "LOC"],
     )
 
     # test 1: LOC 0.=presion=recall

--- a/pii_recognition/evaluation/prediction_error.py
+++ b/pii_recognition/evaluation/prediction_error.py
@@ -6,7 +6,7 @@ from typing import List
 class TokenError:
     annotation: str
     prediction: str
-    token: str
+    text: str
 
 
 @dataclass


### PR DESCRIPTION
### Description
Instead of in-place initialisation with tokeniser, we set evaluator to take an instance of tokeniser.

#### Checklist
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.