### PR TITLE
Replace SampleError with None when no errors found

### DIFF
--- a/pii_recognition/evaluation/model_evaluator.py
+++ b/pii_recognition/evaluation/model_evaluator.py
@@ -75,10 +75,11 @@ class ModelEvaluator:
         tokens: List[str],
         annotations: List[str],
         predictions: List[str],
-    ) -> Tuple[Counter, SampleError]:
+    ) -> Tuple[Counter, Optional[SampleError]]:
         """
-        Given a user text, this function compares the predicted labels (predictions)
-        identified from the text to the labels of ground truth (annotations).
+        Comparing the predicted labels (predictions) identified from a given text to
+        the labels of ground truth (annotations). A counter and a container that holds
+        prediction errors are returned.
         """
         if self._convert_labels:
             predictions = map_labels(predictions, self._convert_labels)
@@ -105,12 +106,18 @@ class ModelEvaluator:
                         text=tokens[i],
                     )
                 )
+        
+        # avoid variable reassignment; otherwise mypy would complain
+        if (sample_error.failed is False) and (not sample_error.token_errors):
+            rectified_sample_error = None  # if no error found
+        else:
+            rectified_sample_error = sample_error
 
-        return label_pair_counter, sample_error
+        return label_pair_counter, rectified_sample_error
 
     def evaluate_sample(
         self, text: str, annotations: List[str]
-    ) -> Tuple[Counter, SampleError]:
+    ) -> Tuple[Counter, Optional[SampleError]]:
         masked_annotations = mask_labels(annotations, self._translated_entities)
 
         # make prediction
@@ -128,12 +135,11 @@ class ModelEvaluator:
             text, tokens, masked_annotations, translated_predictions
         )
 
-        # TODO: if no mistakes return None instead of empty sample_error
         return label_pair_counter, sample_error
 
     def evaulate_all(
         self, texts: List[str], annotations: List[List[str]]
-    ) -> Tuple[List[Counter], List[SampleError]]:
+    ) -> Tuple[List[Counter], List[Optional[SampleError]]]:
         assert len(texts) == len(annotations)
 
         counters = []

--- a/pii_recognition/evaluation/model_evaluator.py
+++ b/pii_recognition/evaluation/model_evaluator.py
@@ -139,7 +139,7 @@ class ModelEvaluator:
 
     def evaulate_all(
         self, texts: List[str], annotations: List[List[str]]
-    ) -> Tuple[List[Counter], List[Optional[SampleError]]]:
+    ) -> Tuple[List[Counter], List[SampleError]]:
         assert len(texts) == len(annotations)
 
         counters = []
@@ -149,7 +149,8 @@ class ModelEvaluator:
                 texts[i], annotations[i]
             )
             counters.append(label_pair_counter)
-            mistakes.append(sample_error)
+            if sample_error is not None:
+                mistakes.append(sample_error)
         return counters, mistakes
 
     def calculate_score(

--- a/pii_recognition/evaluation/model_evaluator.py
+++ b/pii_recognition/evaluation/model_evaluator.py
@@ -106,7 +106,7 @@ class ModelEvaluator:
                         text=tokens[i],
                     )
                 )
-        
+
         # avoid variable reassignment; otherwise mypy would complain
         if (sample_error.failed is False) and (not sample_error.token_errors):
             rectified_sample_error = None  # if no error found

--- a/pii_recognition/evaluation/model_evaluator_test.py
+++ b/pii_recognition/evaluation/model_evaluator_test.py
@@ -258,7 +258,7 @@ def test_evaluate_sample_with_label_conversion(text, mock_recogniser, mock_token
             EvalLabel("I-PER", "I-PER"): 1,
         }
     )
-    assert mistakes == SampleError(token_errors=[], full_text=text, failed=False)
+    assert mistakes is None
 
 
 def test_evaluate_sample_with_mistakes(text, mock_bad_recogniser, mock_tokeniser):
@@ -301,7 +301,7 @@ def test_evaulate_all(text, mock_recogniser, mock_tokeniser):
         ]
         * 2
     )
-    assert mistakes == [SampleError(token_errors=[], full_text=text, failed=False)] * 2
+    assert mistakes == []
 
 
 def test_calculate_score(mock_tokeniser):

--- a/pii_recognition/evaluation/model_evaluator_test.py
+++ b/pii_recognition/evaluation/model_evaluator_test.py
@@ -135,7 +135,7 @@ def test__compare_predicted_and_truth(text):
     assert counter == Counter(
         {EvalLabel("O", "O"): 4, EvalLabel("LOC", "LOC"): 1, EvalLabel("PER", "PER"): 1}
     )
-    assert mistakes == SampleError(token_errors=[], full_text=text, failed=False)
+    assert mistakes is None
 
     # test 2: predicted != truths and 2 mistakes were made
     counter, mistakes = evaluator._compare_predicted_and_truth(
@@ -191,7 +191,7 @@ def test__compare_predicted_and_truth(text):
             EvalLabel("LOCATION", "LOCATION"): 1,
         }
     )
-    assert mistakes == SampleError(token_errors=[], full_text=text, failed=False)
+    assert mistakes is None
 
 
 def test_evaluate_sample_no_label_conversion(text, mock_recogniser, mock_tokeniser):
@@ -208,7 +208,7 @@ def test_evaluate_sample_no_label_conversion(text, mock_recogniser, mock_tokenis
     assert counter == Counter(
         {EvalLabel("O", "O"): 4, EvalLabel("LOC", "LOC"): 1, EvalLabel("PER", "PER"): 1}
     )
-    assert mistakes == SampleError(token_errors=[], full_text=text, failed=False)
+    assert mistakes is None
 
     # test 2: annotated labels not in target_recogniser_entities
     counter, mistakes = evaluator.evaluate_sample(
@@ -217,7 +217,7 @@ def test_evaluate_sample_no_label_conversion(text, mock_recogniser, mock_tokenis
     assert counter == Counter(
         {EvalLabel("O", "O"): 4, EvalLabel("LOC", "LOC"): 1, EvalLabel("PER", "PER"): 1}
     )
-    assert mistakes == SampleError(token_errors=[], full_text=text, failed=False)
+    assert mistakes is None
 
     # test 3: len of annotations mismatch with len of predictions
     counter, mistakes = evaluator.evaluate_sample(


### PR DESCRIPTION
### Description
Do not return `SampleError` object when the model predictions made no error.

#### Checklist
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.