### PR TITLE
Clarify the usage of entity labels in calculation

### DIFF
--- a/pii_recognition/evaluation/model_evaluator.py
+++ b/pii_recognition/evaluation/model_evaluator.py
@@ -22,9 +22,9 @@ class ModelEvaluator:
         tokeniser: an instance of Tokeniser.
         target_recogniser_entities: entities to be evaluated, the entities are labels
             defined within the recogniser model.
-        convert_to_test_labels: a dict {predicted: annotated} facilitate entity conversion
-            between predicted and test labels. Predicted entity labels could differ
-            from test entity labels, e.g., PERSON and PER.
+        convert_to_test_labels: a dict {predicted: annotated} facilitate entity
+            conversion between predicted and test labels. Predicted entity labels could
+            differ from test entity labels, e.g., PERSON and PER.
     """
 
     def __init__(

--- a/pii_recognition/evaluation/model_evaluator.py
+++ b/pii_recognition/evaluation/model_evaluator.py
@@ -154,11 +154,11 @@ class ModelEvaluator:
         return counters, mistakes
 
     def calculate_score(
-        self, all_eval_counters: List[Counter], f_beta: float = 1.0
+        self,
+        all_eval_counters: List[Counter],
+        f_beta: float = 1.0,
+        use_test_labels: bool = True,
     ) -> Tuple[Dict, Dict, Dict]:
-        # TODO: we have test labels and labels come from recogniser,
-        # be specific of which label is used for eval
-
         # aggregate results
         all_results: Counter = sum(all_eval_counters, Counter())
 
@@ -194,4 +194,25 @@ class ModelEvaluator:
             else:
                 entity_f_score[entity] = np.NaN
 
+        # using entity labels in recogniser
+        if (use_test_labels is False) and (self._convert_labels is not None):
+            convert_to_recogniser_labels = {
+                value: key for key, value in self._convert_labels.items()
+            }
+
+            entity_recall = self._convert_metric_labels(
+                entity_recall, convert_to_recogniser_labels
+            )
+            entity_precision = self._convert_metric_labels(
+                entity_precision, convert_to_recogniser_labels
+            )
+            entity_f_score = self._convert_metric_labels(
+                entity_f_score, convert_to_recogniser_labels
+            )
+
         return entity_recall, entity_precision, entity_f_score
+
+    def _convert_metric_labels(
+        self, metric: Dict[str, float], converter: Dict[str, str]
+    ) -> Dict[str, float]:
+        return {converter[name]: score for name, score in metric.items()}

--- a/pii_recognition/evaluation/model_evaluator.py
+++ b/pii_recognition/evaluation/model_evaluator.py
@@ -195,6 +195,7 @@ class ModelEvaluator:
                 entity_f_score[entity] = np.NaN
 
         # use recogniser entity labels
+        # TODO: test the block below
         if (use_test_labels is False) and (self._convert_to_test_labels is not None):
             convert_to_recogniser_labels = {
                 value: key for key, value in self._convert_to_test_labels.items()

--- a/pii_recognition/evaluation/model_evaluator_test.py
+++ b/pii_recognition/evaluation/model_evaluator_test.py
@@ -358,7 +358,14 @@ def test_calculate_score(mock_tokeniser):
             }
         )
     ] * 2
+
     recall, precision, f1 = evaluator.calculate_score(counters)
     assert recall == {"PERSON": 1.0, "LOCATION": 1.0}
     assert precision == {"PERSON": 1.0, "LOCATION": 1.0}
     assert f1 == {"PERSON": 1.0, "LOCATION": 1.0}
+
+    # test 4: with entity mapping and use recogniser labels
+    recall, precision, f1 = evaluator.calculate_score(counters, use_test_labels=False)
+    assert recall == {"PER": 1.0, "LOC": 1.0}
+    assert precision == {"PER": 1.0, "LOC": 1.0}
+    assert f1 == {"PER": 1.0, "LOC": 1.0}

--- a/pii_recognition/evaluation/model_evaluator_test.py
+++ b/pii_recognition/evaluation/model_evaluator_test.py
@@ -64,13 +64,13 @@ def test_class_init():
         recogniser=mock_recogniser,
         tokeniser=mock_tokeniser,
         target_recogniser_entities=["PER", "LOC"],
-        convert_labels={"PER": "PERSON", "LOC": "LOCATION"},
+        convert_to_test_labels={"PER": "PERSON", "LOC": "LOCATION"},
     )
 
     assert evaluator.recogniser == mock_recogniser
     assert evaluator.tokeniser == mock_tokeniser
     assert evaluator.target_recogniser_entities == ["PER", "LOC"]
-    assert evaluator._convert_labels == {"PER": "PERSON", "LOC": "LOCATION"}
+    assert evaluator._convert_to_test_labels == {"PER": "PERSON", "LOC": "LOCATION"}
     assert evaluator._translated_entities == ["PERSON", "LOCATION"]
 
 
@@ -176,7 +176,7 @@ def test__compare_predicted_and_truth(text):
         recogniser=Mock(),
         tokeniser=Mock(),
         target_recogniser_entities=["ANY"],
-        convert_labels={"LOC": "LOCATION", "PER": "PERSON"},
+        convert_to_test_labels={"LOC": "LOCATION", "PER": "PERSON"},
     )
     counter, mistakes = evaluator._compare_predicted_and_truth(
         text,
@@ -246,7 +246,7 @@ def test_evaluate_sample_with_label_conversion(text, mock_recogniser, mock_token
         recogniser=mock_recogniser,
         tokeniser=mock_tokeniser,
         target_recogniser_entities=["PER", "LOC"],
-        convert_labels={"PER": "I-PER", "LOC": "I-LOC"},
+        convert_to_test_labels={"PER": "I-PER", "LOC": "I-LOC"},
     )
     counter, mistakes = evaluator.evaluate_sample(
         text, annotations=["O", "I-MISC", "I-PER", "O", "I-LOC", "I-MISC"]
@@ -266,7 +266,7 @@ def test_evaluate_sample_with_mistakes(text, mock_bad_recogniser, mock_tokeniser
         recogniser=mock_bad_recogniser,
         tokeniser=mock_tokeniser,
         target_recogniser_entities=["PER", "LOC"],
-        convert_labels={"PER": "I-PER", "LOC": "I-LOC"},
+        convert_to_test_labels={"PER": "I-PER", "LOC": "I-LOC"},
     )
     counter, mistakes = evaluator.evaluate_sample(
         text, annotations=["O", "I-MISC", "I-PER", "O", "I-LOC", "I-MISC"]
@@ -347,7 +347,7 @@ def test_calculate_score(mock_tokeniser):
         recogniser=Mock(),
         tokeniser=mock_tokeniser,
         target_recogniser_entities=["PER", "LOC"],
-        convert_labels={"LOC": "LOCATION", "PER": "PERSON"},
+        convert_to_test_labels={"LOC": "LOCATION", "PER": "PERSON"},
     )
     counters = [
         Counter(


### PR DESCRIPTION
### Description
As a matter of fact, we have two sources for the entity labels

- Entities defined by a recogniser model
- Entities defined by the test data

Add an argument to control which label to use for denoting the metrics.

#### Checklist
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.