### PR TITLE
Rename method to register

### DIFF
--- a/pii_recognition/data_readers/__init__.py
+++ b/pii_recognition/data_readers/__init__.py
@@ -7,8 +7,8 @@ from .wnut_reader import WnutReader
 
 def init() -> Registry:
     registry = Registry[Reader]()
-    registry.add_item(ConllReader)
-    registry.add_item(WnutReader)
+    registry.register(ConllReader)
+    registry.register(WnutReader)
 
     return registry
 

--- a/pii_recognition/evaluation/pakkr_pipeline_test.py
+++ b/pii_recognition/evaluation/pakkr_pipeline_test.py
@@ -25,8 +25,8 @@ class RegistryWithConfig:
 def mock_registry():
     # Any is equivalent to Type[Any]
     regsitry: Registry[Any] = Registry()
-    regsitry.add_item(RegistryNoConfig)
-    regsitry.add_item(RegistryWithConfig)
+    regsitry.register(RegistryNoConfig)
+    regsitry.register(RegistryWithConfig)
     return regsitry
 
 

--- a/pii_recognition/recognisers/__init__.py
+++ b/pii_recognition/recognisers/__init__.py
@@ -10,11 +10,11 @@ def init() -> Registry:
     from .stanza_recogniser import StanzaRecogniser
 
     registry = Registry[EntityRecogniser]()
-    registry.add_item(CrfRecogniser)
-    registry.add_item(FirstLetterUppercaseRecogniser)
-    registry.add_item(FlairRecogniser)
-    registry.add_item(SpacyRecogniser)
-    registry.add_item(StanzaRecogniser)
+    registry.register(CrfRecogniser)
+    registry.register(FirstLetterUppercaseRecogniser)
+    registry.register(FlairRecogniser)
+    registry.register(SpacyRecogniser)
+    registry.register(StanzaRecogniser)
 
     return registry
 

--- a/pii_recognition/registration/registry.py
+++ b/pii_recognition/registration/registry.py
@@ -4,7 +4,7 @@ T_co = TypeVar("T_co", covariant=True)
 
 
 class Registry(dict, Generic[T_co]):
-    def add_item(self, item: Type[T_co], name: Optional[str] = None):
+    def register(self, item: Type[T_co], name: Optional[str] = None):
         if name:
             self[name] = item
         else:

--- a/pii_recognition/registration/registry_test.py
+++ b/pii_recognition/registration/registry_test.py
@@ -3,18 +3,18 @@ from typing import Any
 from .registry import Registry
 
 
-def test_Registry_add_item():
+def test_Registry_register():
     class ToyClass:
         pass
 
     # Any is equivalent to Type[Any]
     actual = Registry[Any]()
 
-    actual.add_item(ToyClass)
+    actual.register(ToyClass)
     assert isinstance(actual, dict)
     assert actual["ToyClass"] == ToyClass
 
-    actual.add_item(ToyClass, "TClass")
+    actual.register(ToyClass, "TClass")
     assert isinstance(actual, dict)
     assert actual["TClass"] == ToyClass
 
@@ -26,7 +26,7 @@ def test_Registry_create_instance():
 
     # Any is equivalent to Type[Any]
     registry = Registry[Any]()
-    registry.add_item(ToyClass)
+    registry.register(ToyClass)
 
     actual = registry.create_instance(name="ToyClass", config={"a": "value_a"})
     assert isinstance(actual, ToyClass)

--- a/pii_recognition/tokenisation/__init__.py
+++ b/pii_recognition/tokenisation/__init__.py
@@ -9,15 +9,15 @@ from pii_recognition.tokenisation.tokenisers import Tokeniser, TreebankWordToken
 
 def tokeniser_init() -> Registry:
     registry = Registry[Tokeniser]()
-    registry.add_item(TreebankWordTokeniser)
+    registry.register(TreebankWordTokeniser)
 
     return registry
 
 
 def detokeniser_init() -> Registry:
     registry = Registry[Detokeniser]()
-    registry.add_item(SpaceJoinDetokeniser)
-    registry.add_item(TreebankWordDetokeniser)
+    registry.register(SpaceJoinDetokeniser)
+    registry.register(TreebankWordDetokeniser)
 
     return registry
 


### PR DESCRIPTION
### Description
In `registry` class, rename method of `add_item` to `register`.
