### PR TITLE
Fix tests on metrics

### DIFF
--- a/pii_recognition/evaluation/metrics.py
+++ b/pii_recognition/evaluation/metrics.py
@@ -17,7 +17,8 @@ def compute_label_precision(
     """Compute recall for a designated label.
 
     This can calculate precision for a particular label for both binary and
-    multi-class settings.
+    multi-class settings. This function is not stable when calculating int and
+    str mixed labels, be aware of ValueError about unseen labels.
     """
     return precision_score(y_true, y_pred, average=None, labels=[label_name])[0]
 
@@ -28,6 +29,7 @@ def compute_label_recall(
     """Compute recall for a designated label.
 
     This can calculate recall for a particular label for both binary and
-    multi-class settings.
+    multi-class settings.This function is not stable when calculating int and
+    str mixed labels, be aware of ValueError about unseen labels.
     """
     return recall_score(y_true, y_pred, average=None, labels=[label_name])[0]

--- a/pii_recognition/evaluation/metrics.py
+++ b/pii_recognition/evaluation/metrics.py
@@ -1,7 +1,10 @@
-from typing import List
+from typing import List, TypeVar
 
 import numpy as np
 from sklearn.metrics import precision_score, recall_score
+
+# LT for label type
+LT = TypeVar("LT", int, str)
 
 
 def compute_f_beta(precision: float, recall: float, beta: float = 1.0) -> float:
@@ -12,24 +15,22 @@ def compute_f_beta(precision: float, recall: float, beta: float = 1.0) -> float:
 
 
 def compute_label_precision(
-    y_true: List[str], y_pred: List[str], label_name: str,
+    y_true: List[LT], y_pred: List[LT], label_name: LT,
 ) -> float:
     """Compute recall for a designated label.
 
     This can calculate precision of a particular label for both binary and multi-class
-    settings. The called upon sklearn function is not stable on string and integer mixed
-    labels, may encouter ValueError. So input arguments are required to be in str.
+    settings. The invoked sklearn function is not stable on string and integer mixed
+    labels, may encouter ValueError. So mixed types in an argument is not allowed.
     """
     return precision_score(y_true, y_pred, average=None, labels=[label_name])[0]
 
 
-def compute_label_recall(
-    y_true: List[str], y_pred: List[str], label_name: str,
-) -> float:
+def compute_label_recall(y_true: List[LT], y_pred: List[LT], label_name: LT,) -> float:
     """Compute recall for a designated label.
 
     This can calculate recall of a particular label for both binary and multi-class
-    settings. The called upon sklearn function is not stable on string and integer mixed
-    labels, may encouter ValueError. So input arguments are required to be in str.
+    settings. The invoked sklearn function is not stable on string and integer mixed
+    labels, may encouter ValueError. So mixed types in an arguments is not allowed.
     """
     return recall_score(y_true, y_pred, average=None, labels=[label_name])[0]

--- a/pii_recognition/evaluation/metrics.py
+++ b/pii_recognition/evaluation/metrics.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List
 
 import numpy as np
 from sklearn.metrics import precision_score, recall_score
@@ -12,24 +12,24 @@ def compute_f_beta(precision: float, recall: float, beta: float = 1.0) -> float:
 
 
 def compute_label_precision(
-    y_true: List, y_pred: List, label_name: Union[int, str]
+    y_true: List[str], y_pred: List[str], label_name: str,
 ) -> float:
     """Compute recall for a designated label.
 
-    This can calculate precision for a particular label for both binary and
-    multi-class settings. This function is not stable when calculating int and
-    str mixed labels, be aware of ValueError about unseen labels.
+    This can calculate precision of a particular label for both binary and multi-class
+    settings. The called upon sklearn function is not stable on string and integer mixed
+    labels, may encouter ValueError. So input arguments are required to be in str.
     """
     return precision_score(y_true, y_pred, average=None, labels=[label_name])[0]
 
 
 def compute_label_recall(
-    y_true: List, y_pred: List, label_name: Union[int, str]
+    y_true: List[str], y_pred: List[str], label_name: str,
 ) -> float:
     """Compute recall for a designated label.
 
-    This can calculate recall for a particular label for both binary and
-    multi-class settings.This function is not stable when calculating int and
-    str mixed labels, be aware of ValueError about unseen labels.
+    This can calculate recall of a particular label for both binary and multi-class
+    settings. The called upon sklearn function is not stable on string and integer mixed
+    labels, may encouter ValueError. So input arguments are required to be in str.
     """
     return recall_score(y_true, y_pred, average=None, labels=[label_name])[0]

--- a/pii_recognition/evaluation/metrics_test.py
+++ b/pii_recognition/evaluation/metrics_test.py
@@ -30,47 +30,61 @@ def test_compute_f_beta():
     assert np.isclose(actual, 0.44117647058)
 
 
-def test_compute_label_precision_for_binary():
-    y_true = ["0", "0", "1"]
-    y_pred = ["0", "1", "1"]
+def test_compute_label_precision_for_str():
+    y_true = ["1"]
+    y_pred = ["1"]
     actual = compute_label_precision(y_true, y_pred, label_name="1")
+    assert actual == 1.0
+
+
+def test_compute_label_precision_for_int():
+    y_true = [1]
+    y_pred = [1]
+    actual = compute_label_precision(y_true, y_pred, label_name=1)
+    assert actual == 1.0
+
+
+def test_compute_label_precision_for_binary():
+    y_true = [0, 0, 1]
+    y_pred = [0, 1, 1]
+    actual = compute_label_precision(y_true, y_pred, label_name=1)
     assert actual == 0.5
 
 
 def test_compute_label_precision_for_multiclass():
-    y_true = ["0", "0", "0", "1", "0", "0", "2", "0", "2"]
-    y_pred = ["0", "0", "0", "1", "1", "1", "2", "2", "2"]
-    actual = compute_label_precision(y_true, y_pred, label_name="1")
+    y_true = [0, 0, 0, 1, 0, 0, 2, 0, 2]
+    y_pred = [0, 0, 0, 1, 1, 1, 2, 2, 2]
+    actual = compute_label_precision(y_true, y_pred, label_name=1)
     assert_almost_equal(actual, 0.3333333)
-    actual = compute_label_precision(y_true, y_pred, label_name="2")
+    actual = compute_label_precision(y_true, y_pred, label_name=2)
     assert_almost_equal(actual, 0.6666666)
 
 
 def test_compute_label_precision_for_nonexist_labels():
-    y_true = ["0", "1"]
-    y_pred = ["0", "1"]
-    actual = compute_label_precision(y_true, y_pred, label_name="2")
+    y_true = [0, 1]
+    y_pred = [1, 1]
+    actual = compute_label_precision(y_true, y_pred, label_name=2)
     assert actual == 0.0
 
 
 def test_compute_label_recall_for_binary():
-    y_true = ["0", "1", "1"]
-    y_pred = ["0", "0", "1"]
-    actual = compute_label_recall(y_true, y_pred, label_name="1")
+    y_true = [0, 1, 1]
+    y_pred = [0, 0, 1]
+    actual = compute_label_recall(y_true, y_pred, label_name=1)
     assert actual == 0.5
 
 
 def test_compute_label_recall_for_multiclass():
-    y_true = ["0", "0", "0", "1", "1", "1", "2", "2", "2"]
-    y_pred = ["0", "0", "0", "1", "0", "0", "2", "0", "2"]
-    actual = compute_label_recall(y_true, y_pred, label_name="1")
+    y_true = [0, 0, 0, 1, 1, 1, 2, 2, 2]
+    y_pred = [0, 0, 0, 1, 0, 0, 2, 0, 2]
+    actual = compute_label_recall(y_true, y_pred, label_name=1)
     assert_almost_equal(actual, 0.3333333)
-    actual = compute_label_recall(y_true, y_pred, label_name="2")
+    actual = compute_label_recall(y_true, y_pred, label_name=2)
     assert_almost_equal(actual, 0.6666666)
 
 
 def test_compute_label_recall_for_nonexist_labels():
-    y_true = ["0", "1"]
-    y_pred = ["0", "1"]
-    actual = compute_label_recall(y_true, y_pred, label_name="2")
+    y_true = [0, 1]
+    y_pred = [0, 1]
+    actual = compute_label_recall(y_true, y_pred, label_name=2)
     assert actual == 0.0

--- a/pii_recognition/evaluation/metrics_test.py
+++ b/pii_recognition/evaluation/metrics_test.py
@@ -30,7 +30,7 @@ def test_compute_f_beta():
     assert np.isclose(actual, 0.44117647058)
 
 
-def test_compute_label_precision_for_list_binary():
+def test_compute_label_precision_for_binary():
     y_true = ["0", "0", "1"]
     y_pred = ["0", "1", "1"]
     actual = compute_label_precision(y_true, y_pred, label_name="1")
@@ -67,3 +67,10 @@ def test_compute_label_recall_for_multiclass():
     assert_almost_equal(actual, 0.3333333)
     actual = compute_label_recall(y_true, y_pred, label_name="2")
     assert_almost_equal(actual, 0.6666666)
+
+
+def test_compute_label_recall_for_nonexist_labels():
+    y_true = ["0", "1"]
+    y_pred = ["0", "1"]
+    actual = compute_label_recall(y_true, y_pred, label_name="2")
+    assert actual == 0.0

--- a/pii_recognition/evaluation/metrics_test.py
+++ b/pii_recognition/evaluation/metrics_test.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from numpy.testing import assert_almost_equal
 
 from .metrics import compute_f_beta, compute_label_precision, compute_label_recall
@@ -31,92 +30,40 @@ def test_compute_f_beta():
     assert np.isclose(actual, 0.44117647058)
 
 
-def test_compute_label_precision_for_int_labels():
-    y_true = [0, 1]
-    y_pred = [1, 1]
-    actual = compute_label_precision(y_true, y_pred, label_name=1)
-    assert actual == 0.5
-
-
-def test_compute_label_precision_for_str_labels():
-    y_true = ["label_0", "label_1"]
-    y_pred = ["label_1", "label_1"]
-    actual = compute_label_precision(y_true, y_pred, label_name="label_1")
-    assert actual == 0.5
-
-
-def test_compute_label_precision_for_binary():
-    y_true = [0, 0, 1]
-    y_pred = [0, 1, 1]
-    actual = compute_label_precision(y_true, y_pred, label_name=1)
+def test_compute_label_precision_for_list_binary():
+    y_true = ["0", "0", "1"]
+    y_pred = ["0", "1", "1"]
+    actual = compute_label_precision(y_true, y_pred, label_name="1")
     assert actual == 0.5
 
 
 def test_compute_label_precision_for_multiclass():
-    y_true = [0, 0, 0, 1, 0, 0, 2, 0, 2, "label_0", 0, "label_0", "label_0"]
-    y_pred = [0, 0, 0, 1, 1, 1, 2, 2, 2, "label_0", "label_0", "label_0", "label_0"]
-    actual = compute_label_precision(y_true, y_pred, label_name=1)
+    y_true = ["0", "0", "0", "1", "0", "0", "2", "0", "2"]
+    y_pred = ["0", "0", "0", "1", "1", "1", "2", "2", "2"]
+    actual = compute_label_precision(y_true, y_pred, label_name="1")
     assert_almost_equal(actual, 0.3333333)
-    actual = compute_label_precision(y_true, y_pred, label_name=2)
+    actual = compute_label_precision(y_true, y_pred, label_name="2")
     assert_almost_equal(actual, 0.6666666)
-    actual = compute_label_precision(y_true, y_pred, label_name="label_0")
-    assert actual == 0.75
 
 
-def test_compute_label_precision_for_nonexist_int_labels():
-    y_true = [0, 1]
-    y_pred = [0, 1]
-    actual = compute_label_precision(y_true, y_pred, label_name=2)
+def test_compute_label_precision_for_nonexist_labels():
+    y_true = ["0", "1"]
+    y_pred = ["0", "1"]
+    actual = compute_label_precision(y_true, y_pred, label_name="2")
     assert actual == 0.0
-
-
-def test_compute_label_precision_for_nonexist_str_labels():
-    y_true = ["label_0", "label_1"]
-    y_pred = ["label_0", "label_1"]
-    actual = compute_label_precision(y_true, y_pred, label_name="label_2")
-    assert actual == 0.0
-
-
-def test_compute_label_precision_for_nonexist_mixed_labels():
-    y_true = [0, 1, "label_0", "label_1"]
-    y_pred = [0, 1, "label_0", "label_1"]
-    actual = compute_label_precision(y_true, y_pred, label_name=2)
-    assert actual == 0.0
-    actual = compute_label_precision(y_true, y_pred, label_name="label_2")
-    assert actual == 0.0
-
-
-def test_compute_label_precision_for_str_labels_ask_nonexist_int():
-    y_true = ["label_0", "label_1"]
-    y_pred = ["label_0", "label_1"]
-    actual = compute_label_precision(y_true, y_pred, label_name=1)
-    assert actual == 0.0
-
-
-def test_compute_label_precision_for_int_labels_ask_nonexist_str():
-    # This is a very unexpected edge case
-    # this happens because y_true will be converted to numpy int
-    # but label set gets converted to numpy unicode
-    y_true = [0, 1]
-    y_pred = [0, 1]
-    with pytest.raises(ValueError) as error:
-        compute_label_precision(y_true, y_pred, label_name="label_1")
-    assert str(error.value) == "y contains previously unseen labels: [0, 1]"
 
 
 def test_compute_label_recall_for_binary():
-    y_true = [0, 1, 1]
-    y_pred = [0, 0, 1]
-    actual = compute_label_recall(y_true, y_pred, label_name=1)
+    y_true = ["0", "1", "1"]
+    y_pred = ["0", "0", "1"]
+    actual = compute_label_recall(y_true, y_pred, label_name="1")
     assert actual == 0.5
 
 
 def test_compute_label_recall_for_multiclass():
-    y_true = [0, 0, 0, 1, 1, 1, 2, 2, 2, "label_0", "label_0", "label_0", "label_0"]
-    y_pred = [0, 0, 0, 1, 0, 0, 2, 0, 2, "label_0", 0, "label_0", "label_0"]
-    actual = compute_label_recall(y_true, y_pred, label_name=1)
+    y_true = ["0", "0", "0", "1", "1", "1", "2", "2", "2"]
+    y_pred = ["0", "0", "0", "1", "0", "0", "2", "0", "2"]
+    actual = compute_label_recall(y_true, y_pred, label_name="1")
     assert_almost_equal(actual, 0.3333333)
-    actual = compute_label_recall(y_true, y_pred, label_name=2)
+    actual = compute_label_recall(y_true, y_pred, label_name="2")
     assert_almost_equal(actual, 0.6666666)
-    actual = compute_label_recall(y_true, y_pred, label_name="label_0")
-    assert actual == 0.75


### PR DESCRIPTION
### Description
Split a test into multiple small functions where each function tests on a specific thing.

One thing I found during testing was that we would encounter a ValueError when testing on integer and string mixed labels, that because underlying numpy would adopt different strategies converting them and as a result the dtype of np arraies conflict.

For example, in sklearn it would take input arrays and labels for a conversion

- y_pred [0, 1] --> numpy --> np.array([0, 1])

- asked for "LOC" --> label set --> numpy --> np.array(["0", "1", "LOC"])

- Miss-match between 0 and "0", 1 and "1"

The proposed solution is requiring every argument passed to scoring to be str type.


#### Checklist
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.