### PR TITLE
Rollup metric for boundary detection of PII entities

### DIFF
--- a/pii_recognition/evaluation/character_level_evaluation.py
+++ b/pii_recognition/evaluation/character_level_evaluation.py
@@ -1,7 +1,8 @@
 from dataclasses import asdict
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from pii_recognition.evaluation.metrics import (
+    compute_f_beta,
     compute_label_precision,
     compute_label_recall,
 )
@@ -97,3 +98,32 @@ def compute_entity_recalls_for_ground_truth(
         recalls.append(entity_dict)
 
     return recalls
+
+
+def compute_pii_detection_f1(
+    precisions: List[float],
+    recalls: List[float],
+    recall_threshold: Optional[float] = None,
+) -> float:
+    """Evaluate performance of PII detection with F1.
+
+    Rollup precisions and recalls to calculate F1 on boundary detection for PII
+    recognition. Recall thresholding is supported, if the system can recognise
+    a certain portion of an entity beyond the threshold, we will consider it a
+    success.
+
+    Args:
+        precisions: a list of entity precision values.
+        recalls: a list of entity recall values.
+        recall_threshold: a float between 0 and 1. Any value greater than or equals
+            to the threshold would be rounded up to 1.
+
+    Returns:
+        F1 score.
+    """
+    if recall_threshold:
+        recalls = [1.0 if item >= recall_threshold else item for item in recalls]
+
+    ave_precision = sum(precisions) / len(precisions)
+    ave_recall = sum(recalls) / len(recalls)
+    return compute_f_beta(ave_precision, ave_recall)

--- a/pii_recognition/evaluation/character_level_evaluation.py
+++ b/pii_recognition/evaluation/character_level_evaluation.py
@@ -122,6 +122,20 @@ def compute_pii_detection_f1(
         F1 score.
     """
     if recall_threshold:
+        if recall_threshold > 1.0 or recall_threshold < 0.0:
+            raise ValueError(
+                f"Invalid threshold! Recall threshold must between 0 and 1 "
+                f"but got {recall_threshold}"
+            )
+
+    if not precisions and not recalls:
+        raise ValueError("You are passing empty precisions and recalls lists!")
+    if not precisions:
+        raise ValueError("You are passing empty precisions list!")
+    elif not recalls:
+        raise ValueError("You are passing empty recalls list!")
+
+    if recall_threshold:
         recalls = [1.0 if item >= recall_threshold else item for item in recalls]
 
     ave_precision = sum(precisions) / len(precisions)

--- a/pii_recognition/evaluation/character_level_evaluation_test.py
+++ b/pii_recognition/evaluation/character_level_evaluation_test.py
@@ -1,9 +1,11 @@
 from typing import List
+from numpy.testing import assert_almost_equal
 
 import pytest
 from pii_recognition.evaluation.character_level_evaluation import (
     compute_entity_precisions_for_prediction,
     compute_entity_recalls_for_ground_truth,
+    compute_pii_detection_f1,
     label_encoder,
 )
 from pii_recognition.labels.schema import Entity
@@ -393,3 +395,31 @@ def test_compute_precisions_recalls_for_no_true():
         {"entity_type": "PER", "start": 10, "end": 15, "precision": 0.0},
     ]
     assert recalls == []
+
+
+def test_compute_pii_detection_f1_for_no_recall_threshold_f1_is_one():
+    precisions = [1.0, 1.0]
+    recalls = [1.0, 1.0]
+    actual = compute_pii_detection_f1(precisions, recalls)
+    assert actual == 1.0
+
+
+def test_compute_pii_detection_f1_for_no_recall_threshold_f1_is_zero():
+    precisions = [0.0, 0.0]
+    recalls = [0.0, 0.0]
+    actual = compute_pii_detection_f1(precisions, recalls)
+    assert actual == 0.0
+
+
+def test_compute_pii_detection_f1_for_no_recall_threshold():
+    precisions = [0.4, 0.8]
+    recalls = [0.2, 0.7]
+    actual = compute_pii_detection_f1(precisions, recalls)
+    assert_almost_equal(actual, 0.5142857)
+
+
+def test_compute_pii_detection_f1_with_recall_threshold():
+    precisions = [0.4, 0.8, 0.9]
+    recalls = [0.2, 0.51, 0.7]
+    actual = compute_pii_detection_f1(precisions, recalls, recall_threshold=0.5)
+    assert_almost_equal(actual, 0.716279)

--- a/pii_recognition/evaluation/character_level_evaluation_test.py
+++ b/pii_recognition/evaluation/character_level_evaluation_test.py
@@ -423,3 +423,30 @@ def test_compute_pii_detection_f1_with_recall_threshold():
     recalls = [0.2, 0.51, 0.7]
     actual = compute_pii_detection_f1(precisions, recalls, recall_threshold=0.5)
     assert_almost_equal(actual, 0.716279)
+
+
+def test_compute_pii_detection_f1_for_invalid_threshold():
+    precisions = recalls = [0.0]
+    with pytest.raises(ValueError) as err:
+        compute_pii_detection_f1(precisions, recalls, recall_threshold=2.0)
+    assert str(err.value) == (
+        "Invalid threshold! Recall threshold must between 0 and 1 but got 2.0"
+    )
+
+
+def test_compute_pii_detection_f1_for_empty_precisions():
+    with pytest.raises(ValueError) as err:
+        compute_pii_detection_f1([], [0.0], recall_threshold=0.5)
+    assert str(err.value) == "You are passing empty precisions list!"
+
+
+def test_compute_pii_detection_f1_for_empty_recalls():
+    with pytest.raises(ValueError) as err:
+        compute_pii_detection_f1([0.0], [], recall_threshold=0.5)
+    assert str(err.value) == "You are passing empty recalls list!"
+
+
+def test_compute_pii_detection_f1_for_empty_precisions_recalls():
+    with pytest.raises(ValueError) as err:
+        compute_pii_detection_f1([], [], recall_threshold=0.5)
+    assert str(err.value) == "You are passing empty precisions and recalls lists!"

--- a/pii_recognition/evaluation/metrics.py
+++ b/pii_recognition/evaluation/metrics.py
@@ -8,8 +8,11 @@ LT = TypeVar("LT", int, str)
 
 
 def compute_f_beta(precision: float, recall: float, beta: float = 1.0) -> float:
-    if np.isnan(precision) or np.isnan(recall) or (precision == 0 and recall == 0):
-        return np.nan
+    if np.isnan(precision) or np.isnan(recall):
+        return float("nan")
+
+    if precision == 0.0 and recall == 0.0:
+        return 0.0
 
     return ((1 + beta ** 2) * precision * recall) / (((beta ** 2) * precision) + recall)
 

--- a/pii_recognition/evaluation/metrics_test.py
+++ b/pii_recognition/evaluation/metrics_test.py
@@ -4,18 +4,18 @@ from numpy.testing import assert_almost_equal
 from .metrics import compute_f_beta, compute_label_precision, compute_label_recall
 
 
-def test_compute_f_beta_for_zero_division():
+def test_compute_f_beta_for_zero_precision_recall():
     actual = compute_f_beta(0.0, 0.0)
-    assert np.isnan(actual)
+    assert actual == 0.0
 
 
 def test_compute_f_beta_for_nan_numerator():
-    actual = compute_f_beta(np.nan, 1.0)
+    actual = compute_f_beta(float("nan"), 1.0)
     assert np.isnan(actual)
 
 
 def test_test_compute_f_beta_for_nan_denominator():
-    actual = compute_f_beta(1.0, np.nan)
+    actual = compute_f_beta(1.0, float("nan"))
     assert np.isnan(actual)
 
 

--- a/pii_recognition/evaluation/model_evaluator_test.py
+++ b/pii_recognition/evaluation/model_evaluator_test.py
@@ -2,7 +2,6 @@ from collections import Counter
 from typing import List
 from unittest.mock import Mock
 
-import numpy as np
 import pytest
 from pytest import fixture
 
@@ -323,7 +322,7 @@ def test_calculate_score(mock_recogniser, mock_tokeniser):
     recall, precision, f1 = evaluator.calculate_score(counters)
     assert recall == {"PER": 1.0, "LOC": 0.0}
     assert precision == {"PER": 1.0, "LOC": 0.0}
-    assert f1 == {"PER": 1.0, "LOC": np.nan}
+    assert f1 == {"PER": 1.0, "LOC": 0.0}
 
     # test 2: multiple texts
     counters = [


### PR DESCRIPTION
### Description
Calculate a score, which is f1, measures the performance of PII detection. This is one of many rollup strategies, for this specific metric, we won't care about whether types matched for the predicted entities, we only care about the boundaries.

A threshold on recall is allowed. We can set the threshold to any value between 0 and 1. Suppose we set this threshold to 0.5, that means any recall value >= 0.5 will be roundup to 1. This equivalent to say, obscuring at least half of an entity can be counted as a success.

#### Checklist
- [x] Added **tests** for changed code.
