### PR TITLE
Add a pipeline step to calculate precisions and recalls for PII recognition

### DIFF
--- a/pii_recognition/evaluation/character_level_evaluation.py
+++ b/pii_recognition/evaluation/character_level_evaluation.py
@@ -13,12 +13,14 @@ from pii_recognition.labels.schema import Entity
 class EntityPrecision:
     entity: Entity
     precision: float
+    entity_src: str = "predicted"
 
 
 @dataclass
 class EntityRecall:
     entity: Entity
     recall: float
+    entity_src: str = "ground_truth"
 
 
 @dataclass

--- a/pii_recognition/evaluation/character_level_evaluation.py
+++ b/pii_recognition/evaluation/character_level_evaluation.py
@@ -155,6 +155,7 @@ def compute_pii_detection_f1(
     precisions: List[float],
     recalls: List[float],
     recall_threshold: Optional[float] = None,
+    beta: float = 1
 ) -> float:
     """Evaluate performance of PII detection with F1.
 
@@ -191,4 +192,4 @@ def compute_pii_detection_f1(
 
     ave_precision = sum(precisions) / len(precisions)
     ave_recall = sum(recalls) / len(recalls)
-    return compute_f_beta(ave_precision, ave_recall)
+    return compute_f_beta(ave_precision, ave_recall, beta)

--- a/pii_recognition/evaluation/character_level_evaluation.py
+++ b/pii_recognition/evaluation/character_level_evaluation.py
@@ -96,8 +96,6 @@ def label_encoder(
                 f"Entity span index is out of range: text length is "
                 f"{text_length} but got span index {e}."
             )
-        label_name = span.entity_type
-
         code[s:e] = [label_code] * (e - s)
 
     return code

--- a/pii_recognition/evaluation/character_level_evaluation.py
+++ b/pii_recognition/evaluation/character_level_evaluation.py
@@ -24,7 +24,7 @@ class EntityRecall:
 
 
 @dataclass
-class TicketScore:
+class TextScore:
     precisions: List[EntityPrecision]
     recalls: List[EntityRecall]
 

--- a/pii_recognition/evaluation/character_level_evaluation.py
+++ b/pii_recognition/evaluation/character_level_evaluation.py
@@ -1,4 +1,4 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Set
 
 from pii_recognition.evaluation.metrics import (

--- a/pii_recognition/evaluation/character_level_evaluation.py
+++ b/pii_recognition/evaluation/character_level_evaluation.py
@@ -36,12 +36,12 @@ def build_label_mapping(
     """Map an entity label to an integer.
 
     Create a dictionary for mapping entity labels. Targeted entity labels are mapped to
-    a positive integer starting from 1 and labels in the same group are mapped to the
-    same integer. Non-targeted labels are mapped to zero.
+    a positive integer starting from 1 and labels within the same group are mapped to
+    the same integer. Non-targeted labels are mapped to zero.
 
     Args:
-        grouped_targeted_labels: entity labels we are interested that have been grouped
-            into multiple clusters.
+        grouped_targeted_labels: entity labels we are interested that have been
+            separated by groups.
         nontargeted_labels: entity labels we are not interested.
 
     Returns:
@@ -74,7 +74,7 @@ def label_encoder(
         label_to_int: a dictionary that keys are entity labels and values are integers.
 
     Returns:
-        Integer code for the text.
+        Integer code of the text.
     """
     # note 0 means negative labels
     code = [0] * text_length

--- a/pii_recognition/evaluation/character_level_evaluation_test.py
+++ b/pii_recognition/evaluation/character_level_evaluation_test.py
@@ -1,8 +1,9 @@
 from typing import List
-from numpy.testing import assert_almost_equal
 
 import pytest
+from numpy.testing import assert_almost_equal
 from pii_recognition.evaluation.character_level_evaluation import (
+    build_label_mapping,
     compute_entity_precisions_for_prediction,
     compute_entity_recalls_for_ground_truth,
     compute_pii_detection_f1,
@@ -450,3 +451,18 @@ def test_compute_pii_detection_f1_for_empty_precisions_recalls():
     with pytest.raises(ValueError) as err:
         compute_pii_detection_f1([], [], recall_threshold=0.5)
     assert str(err.value) == "You are passing empty precisions and recalls lists!"
+
+
+def test_build_label_mapping_with_nontargeted_labels():
+    grouped_targeted_labels = [{"PERSON", "PER"}, {"LOCATION"}, {"DATE"}]
+    nontargeted_labels = {"NONTARGETED"}
+
+    actual = build_label_mapping(grouped_targeted_labels, nontargeted_labels)
+    assert actual == {"PERSON": 1, "PER": 1, "LOCATION": 2, "DATE": 3, "NONTARGETED": 0}
+
+
+def test_build_label_mapping_without_nontargeted_labels():
+    grouped_targeted_labels = [{"PERSON", "PER"}, {"LOCATION"}, {"DATE"}]
+
+    actual = build_label_mapping(grouped_targeted_labels)
+    assert actual == {"PERSON": 1, "PER": 1, "LOCATION": 2, "DATE": 3}

--- a/pii_recognition/evaluation/character_level_evaluation_test.py
+++ b/pii_recognition/evaluation/character_level_evaluation_test.py
@@ -8,17 +8,10 @@ from pii_recognition.evaluation.character_level_evaluation import (
     compute_entity_recalls_for_ground_truth,
     compute_pii_detection_f1,
     label_encoder,
+    EntityRecall,
+    EntityPrecision,
 )
 from pii_recognition.labels.schema import Entity
-
-
-def test_label_encoder_for_reserved_0_taken():
-    with pytest.raises(ValueError) as err:
-        label_encoder(3, [], {"LOC": 0})
-    assert str(err.value) == (
-        "Value 0 is reserved! If a character does not "
-        "belong to any entity, it would be assigned with 0."
-    )
 
 
 def test_label_encoder_for_multi_labels():
@@ -71,16 +64,16 @@ def test_compute_precisions_recalls_for_exact_match():
         50, true_entities, pred_entities, label_to_int
     )
     assert precisions == [
-        {"entity_type": "LOC", "start": 3, "end": 7, "precision": 1.0},
-        {"entity_type": "PER", "start": 10, "end": 15, "precision": 1.0},
-        {"entity_type": "LOC", "start": 23, "end": 32, "precision": 1.0},
-        {"entity_type": "PER", "start": 37, "end": 48, "precision": 1.0},
+        EntityPrecision(Entity(entity_type="LOC", start=3, end=7), 1.0),
+        EntityPrecision(Entity(entity_type="PER", start=10, end=15), 1.0),
+        EntityPrecision(Entity(entity_type="LOC", start=23, end=32), 1.0),
+        EntityPrecision(Entity(entity_type="PER", start=37, end=48), 1.0),
     ]
     assert recalls == [
-        {"entity_type": "LOC", "start": 3, "end": 7, "recall": 1.0},
-        {"entity_type": "PER", "start": 10, "end": 15, "recall": 1.0},
-        {"entity_type": "LOC", "start": 23, "end": 32, "recall": 1.0},
-        {"entity_type": "PER", "start": 37, "end": 48, "recall": 1.0},
+        EntityRecall(Entity(entity_type="LOC", start=3, end=7), 1.0),
+        EntityRecall(Entity(entity_type="PER", start=10, end=15), 1.0),
+        EntityRecall(Entity(entity_type="LOC", start=23, end=32), 1.0),
+        EntityRecall(Entity(entity_type="PER", start=37, end=48), 1.0),
     ]
 
 
@@ -108,16 +101,16 @@ def test_compute_precisions_recalls_for_pred_subset_of_true():
         50, true_entities, pred_entities, label_to_int
     )
     assert precisions == [
-        {"entity_type": "LOC", "start": 4, "end": 7, "precision": 1.0},
-        {"entity_type": "PER", "start": 13, "end": 15, "precision": 1.0},
-        {"entity_type": "LOC", "start": 25, "end": 30, "precision": 1.0},
-        {"entity_type": "PER", "start": 40, "end": 46, "precision": 1.0},
+        EntityPrecision(Entity(entity_type="LOC", start=4, end=7), 1.0),
+        EntityPrecision(Entity(entity_type="PER", start=13, end=15), 1.0),
+        EntityPrecision(Entity(entity_type="LOC", start=25, end=30), 1.0),
+        EntityPrecision(Entity(entity_type="PER", start=40, end=46), 1.0),
     ]
     assert recalls == [
-        {"entity_type": "LOC", "start": 3, "end": 7, "recall": 0.75},
-        {"entity_type": "PER", "start": 10, "end": 15, "recall": 0.4},
-        {"entity_type": "LOC", "start": 23, "end": 32, "recall": 5 / 9},
-        {"entity_type": "PER", "start": 37, "end": 48, "recall": 6 / 11},
+        EntityRecall(Entity(entity_type="LOC", start=3, end=7), 0.75),
+        EntityRecall(Entity(entity_type="PER", start=10, end=15), 0.4),
+        EntityRecall(Entity(entity_type="LOC", start=23, end=32), 5 / 9),
+        EntityRecall(Entity(entity_type="PER", start=37, end=48), 6 / 11),
     ]
 
 
@@ -145,16 +138,16 @@ def test_compute_precisions_recalls_for_pred_superset_of_true():
         50, true_entities, pred_entities, label_to_int
     )
     assert precisions == [
-        {"entity_type": "LOC", "start": 3, "end": 7, "precision": 0.75},
-        {"entity_type": "PER", "start": 10, "end": 15, "precision": 0.4},
-        {"entity_type": "LOC", "start": 23, "end": 32, "precision": 5 / 9},
-        {"entity_type": "PER", "start": 37, "end": 48, "precision": 6 / 11},
+        EntityPrecision(Entity(entity_type="LOC", start=3, end=7), 0.75),
+        EntityPrecision(Entity(entity_type="PER", start=10, end=15), 0.4),
+        EntityPrecision(Entity(entity_type="LOC", start=23, end=32), 5 / 9),
+        EntityPrecision(Entity(entity_type="PER", start=37, end=48), 6 / 11),
     ]
     assert recalls == [
-        {"entity_type": "LOC", "start": 4, "end": 7, "recall": 1.0},
-        {"entity_type": "PER", "start": 13, "end": 15, "recall": 1.0},
-        {"entity_type": "LOC", "start": 25, "end": 30, "recall": 1.0},
-        {"entity_type": "PER", "start": 40, "end": 46, "recall": 1.0},
+        EntityRecall(Entity(entity_type="LOC", start=4, end=7), 1.0),
+        EntityRecall(Entity(entity_type="PER", start=13, end=15), 1.0),
+        EntityRecall(Entity(entity_type="LOC", start=25, end=30), 1.0),
+        EntityRecall(Entity(entity_type="PER", start=40, end=46), 1.0),
     ]
 
 
@@ -182,16 +175,16 @@ def test_compute_precisions_recalls_for_pred_overlap_true():
         50, true_entities, pred_entities, label_to_int
     )
     assert precisions == [
-        {"entity_type": "LOC", "start": 1, "end": 4, "precision": 1 / 3},
-        {"entity_type": "PER", "start": 13, "end": 18, "precision": 0.4},
-        {"entity_type": "LOC", "start": 28, "end": 35, "precision": 4 / 7},
-        {"entity_type": "PER", "start": 45, "end": 49, "precision": 0.75},
+        EntityPrecision(Entity(entity_type="LOC", start=1, end=4), 1 / 3),
+        EntityPrecision(Entity(entity_type="PER", start=13, end=18), 0.4),
+        EntityPrecision(Entity(entity_type="LOC", start=28, end=35), 4 / 7),
+        EntityPrecision(Entity(entity_type="PER", start=45, end=49), 0.75),
     ]
     assert recalls == [
-        {"entity_type": "LOC", "start": 3, "end": 7, "recall": 0.25},
-        {"entity_type": "PER", "start": 10, "end": 15, "recall": 0.4},
-        {"entity_type": "LOC", "start": 23, "end": 32, "recall": 4 / 9},
-        {"entity_type": "PER", "start": 37, "end": 48, "recall": 3 / 11},
+        EntityRecall(Entity(entity_type="LOC", start=3, end=7), 0.25),
+        EntityRecall(Entity(entity_type="PER", start=10, end=15), 0.4),
+        EntityRecall(Entity(entity_type="LOC", start=23, end=32), 4 / 9),
+        EntityRecall(Entity(entity_type="PER", start=37, end=48), 3 / 11),
     ]
 
 
@@ -217,14 +210,14 @@ def test_compute_precisions_recalls_for_no_overlap():
         50, true_entities, pred_entities, label_to_int
     )
     assert precisions == [
-        {"entity_type": "LOC", "start": 15, "end": 20, "precision": 0.0},
-        {"entity_type": "PER", "start": 33, "end": 35, "precision": 0.0},
+        EntityPrecision(Entity(entity_type="LOC", start=15, end=20), 0.0),
+        EntityPrecision(Entity(entity_type="PER", start=33, end=35), 0.0),
     ]
     assert recalls == [
-        {"entity_type": "LOC", "start": 3, "end": 7, "recall": 0.0},
-        {"entity_type": "PER", "start": 10, "end": 15, "recall": 0.0},
-        {"entity_type": "LOC", "start": 23, "end": 32, "recall": 0.0},
-        {"entity_type": "PER", "start": 37, "end": 48, "recall": 0.0},
+        EntityRecall(Entity(entity_type="LOC", start=3, end=7), 0.0),
+        EntityRecall(Entity(entity_type="PER", start=10, end=15), 0.0),
+        EntityRecall(Entity(entity_type="LOC", start=23, end=32), 0.0),
+        EntityRecall(Entity(entity_type="PER", start=37, end=48), 0.0),
     ]
 
 
@@ -251,14 +244,14 @@ def test_compute_precisions_recalls_for_one_pred_to_many_trues():
         50, true_entities, pred_entities, label_to_int
     )
     assert precisions == [
-        {"entity_type": "LOC", "start": 3, "end": 20, "precision": 4 / 17},
-        {"entity_type": "PER", "start": 28, "end": 43, "precision": 0.4},
+        EntityPrecision(Entity(entity_type="LOC", start=3, end=20), 4 / 17),
+        EntityPrecision(Entity(entity_type="PER", start=28, end=43), 0.4),
     ]
     assert recalls == [
-        {"entity_type": "LOC", "start": 3, "end": 7, "recall": 1.0},
-        {"entity_type": "PER", "start": 10, "end": 15, "recall": 0.0},
-        {"entity_type": "LOC", "start": 23, "end": 32, "recall": 0.0},
-        {"entity_type": "PER", "start": 37, "end": 48, "recall": 6 / 11},
+        EntityRecall(Entity(entity_type="LOC", start=3, end=7), 1.0),
+        EntityRecall(Entity(entity_type="PER", start=10, end=15), 0.0),
+        EntityRecall(Entity(entity_type="LOC", start=23, end=32), 0.0),
+        EntityRecall(Entity(entity_type="PER", start=37, end=48), 6 / 11),
     ]
 
 
@@ -285,14 +278,14 @@ def test_compute_precisions_recalls_for_many_preds_to_one_true():
         50, true_entities, pred_entities, label_to_int
     )
     assert precisions == [
-        {"entity_type": "LOC", "start": 3, "end": 7, "precision": 1.0},
-        {"entity_type": "PER", "start": 10, "end": 15, "precision": 0.0},
-        {"entity_type": "LOC", "start": 23, "end": 32, "precision": 0.0},
-        {"entity_type": "PER", "start": 37, "end": 48, "precision": 6 / 11},
+        EntityPrecision(Entity(entity_type="LOC", start=3, end=7), 1.0),
+        EntityPrecision(Entity(entity_type="PER", start=10, end=15), 0.0),
+        EntityPrecision(Entity(entity_type="LOC", start=23, end=32), 0.0),
+        EntityPrecision(Entity(entity_type="PER", start=37, end=48), 6 / 11),
     ]
     assert recalls == [
-        {"entity_type": "LOC", "start": 3, "end": 20, "recall": 4 / 17},
-        {"entity_type": "PER", "start": 28, "end": 43, "recall": 0.4},
+        EntityRecall(Entity(entity_type="LOC", start=3, end=20), 4 / 17),
+        EntityRecall(Entity(entity_type="PER", start=28, end=43), 0.4),
     ]
 
 
@@ -316,12 +309,12 @@ def test_compute_precisions_recalls_for_incorrect_type():
         50, true_entities, pred_entities, label_to_int
     )
     assert precisions == [
-        {"entity_type": "PER", "start": 3, "end": 7, "precision": 0.0},
-        {"entity_type": "LOC", "start": 10, "end": 15, "precision": 0.0},
+        EntityPrecision(Entity(entity_type="PER", start=3, end=7), 0.0),
+        EntityPrecision(Entity(entity_type="LOC", start=10, end=15), 0.0),
     ]
     assert recalls == [
-        {"entity_type": "LOC", "start": 3, "end": 7, "recall": 0.0},
-        {"entity_type": "PER", "start": 10, "end": 15, "recall": 0.0},
+        EntityRecall(Entity(entity_type="LOC", start=3, end=7), 0.0),
+        EntityRecall(Entity(entity_type="PER", start=10, end=15), 0.0),
     ]
 
 
@@ -345,12 +338,12 @@ def test_compute_precisions_recalls_for_type_doesnt_matter():
         50, true_entities, pred_entities, label_to_int
     )
     assert precisions == [
-        {"entity_type": "PER", "start": 3, "end": 7, "precision": 1.0},
-        {"entity_type": "LOC", "start": 10, "end": 15, "precision": 1.0},
+        EntityPrecision(Entity(entity_type="PER", start=3, end=7), 1.0),
+        EntityPrecision(Entity(entity_type="LOC", start=10, end=15), 1.0),
     ]
     assert recalls == [
-        {"entity_type": "LOC", "start": 3, "end": 7, "recall": 1.0},
-        {"entity_type": "PER", "start": 10, "end": 15, "recall": 1.0},
+        EntityRecall(Entity(entity_type="LOC", start=3, end=7), 1.0),
+        EntityRecall(Entity(entity_type="PER", start=10, end=15), 1.0),
     ]
 
 
@@ -371,8 +364,8 @@ def test_compute_precisions_recalls_for_no_pred():
     )
     assert precisions == []
     assert recalls == [
-        {"entity_type": "LOC", "start": 3, "end": 7, "recall": 0.0},
-        {"entity_type": "PER", "start": 10, "end": 15, "recall": 0.0},
+        EntityRecall(Entity(entity_type="LOC", start=3, end=7), 0.0),
+        EntityRecall(Entity(entity_type="PER", start=10, end=15), 0.0),
     ]
 
 
@@ -392,8 +385,8 @@ def test_compute_precisions_recalls_for_no_true():
         50, true_entities, pred_entities, label_to_int
     )
     assert precisions == [
-        {"entity_type": "LOC", "start": 3, "end": 7, "precision": 0.0},
-        {"entity_type": "PER", "start": 10, "end": 15, "precision": 0.0},
+        EntityPrecision(Entity(entity_type="LOC", start=3, end=7), 0.0),
+        EntityPrecision(Entity(entity_type="PER", start=10, end=15), 0.0),
     ]
     assert recalls == []
 

--- a/pii_recognition/pipelines/pii_validation_pipeline.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline.py
@@ -1,8 +1,14 @@
-from typing import Dict
+from typing import Dict, List, Set, Optional
 
 from pakkr import returns
 from pii_recognition.data_readers.data import Data
 from pii_recognition.data_readers.presidio_fake_pii_reader import PresidioFakePiiReader
+from pii_recognition.evaluation.character_level_evaluation import (
+    TicketScore,
+    build_label_mapping,
+    compute_entity_precisions_for_prediction,
+    compute_entity_recalls_for_ground_truth,
+)
 from pii_recognition.recognisers import registry as recogniser_registry
 from pii_recognition.recognisers.entity_recogniser import EntityRecogniser
 
@@ -24,3 +30,30 @@ def identify_pii_entities(
     for item in data.items:
         item.pred_labels = recogniser.analyse(item.text, recogniser.supported_entities)
     return data
+
+
+@returns(List)
+def calculate_precisions_and_recalls(
+    data: Data,
+    grouped_targeted_labels: List[Set[str]],
+    nontargeted_labels: Optional[Set[str]] = None,
+) -> List[TicketScore]:
+    label_mapping = build_label_mapping(grouped_targeted_labels, nontargeted_labels)
+
+    scores = []
+    for item in data.items:
+        if item.pred_labels:
+            pred_labels = item.pred_labels
+        else:  # pred_labels could be None
+            pred_labels = []
+
+        ent_precisions = compute_entity_precisions_for_prediction(
+            len(item.text), item.true_labels, pred_labels, label_mapping
+        )
+        ent_recalls = compute_entity_recalls_for_ground_truth(
+            len(item.text), item.true_labels, pred_labels, label_mapping
+        )
+        ticket_score = TicketScore(precisions=ent_precisions, recalls=ent_recalls)
+        scores.append(ticket_score)
+
+    return scores

--- a/pii_recognition/pipelines/pii_validation_pipeline.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline.py
@@ -4,7 +4,7 @@ from pakkr import returns
 from pii_recognition.data_readers.data import Data
 from pii_recognition.data_readers.presidio_fake_pii_reader import PresidioFakePiiReader
 from pii_recognition.evaluation.character_level_evaluation import (
-    TicketScore,
+    TextScore,
     build_label_mapping,
     compute_entity_precisions_for_prediction,
     compute_entity_recalls_for_ground_truth,
@@ -37,7 +37,7 @@ def calculate_precisions_and_recalls(
     data: Data,
     grouped_targeted_labels: List[Set[str]],
     nontargeted_labels: Optional[Set[str]] = None,
-) -> List[TicketScore]:
+) -> List[TextScore]:
     label_mapping = build_label_mapping(grouped_targeted_labels, nontargeted_labels)
 
     scores = []
@@ -53,7 +53,7 @@ def calculate_precisions_and_recalls(
         ent_recalls = compute_entity_recalls_for_ground_truth(
             len(item.text), item.true_labels, pred_labels, label_mapping
         )
-        ticket_score = TicketScore(precisions=ent_precisions, recalls=ent_recalls)
+        ticket_score = TextScore(precisions=ent_precisions, recalls=ent_recalls)
         scores.append(ticket_score)
 
     return scores

--- a/pii_recognition/pipelines/pii_validation_pipeline_test.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline_test.py
@@ -1,7 +1,7 @@
 from mock import patch
 from pii_recognition.data_readers.data import Data, DataItem
 from pii_recognition.evaluation.character_level_evaluation import (
-    TicketScore,
+    TextScore,
     EntityPrecision,
     EntityRecall,
 )
@@ -64,10 +64,10 @@ def test_calculate_precisions_and_recalls_with_empty_predictions(data):
 
     actual = calculate_precisions_and_recalls(data, grouped_targeted_labels)
     assert len(actual) == 2
-    assert actual[0] == TicketScore(
+    assert actual[0] == TextScore(
         precisions=[], recalls=[EntityRecall(Entity("BIRTHDAY", 21, 31), 0.0)]
     )
-    assert actual[1] == TicketScore(
+    assert actual[1] == TextScore(
         precisions=[],
         recalls=[
             EntityRecall(Entity("ORGANIZATION", 15, 30), 0.0),
@@ -86,11 +86,11 @@ def test_calculate_precisions_and_recalls_with_predictions(data):
 
     actual = calculate_precisions_and_recalls(data, grouped_targeted_labels)
     assert len(actual) == 2
-    assert actual[0] == TicketScore(
+    assert actual[0] == TextScore(
         precisions=[EntityPrecision(Entity("BIRTHDAY", 0, 10), 0.0)],
         recalls=[EntityRecall(Entity("BIRTHDAY", 21, 31), 0.0)],
     )
-    assert actual[1] == TicketScore(
+    assert actual[1] == TextScore(
         precisions=[
             EntityPrecision(Entity("ORGANIZATION", 20, 30), 1.0),
             EntityPrecision(Entity("LOCATION", 30, 46), 0.75),
@@ -110,8 +110,8 @@ def test_calculate_precisions_and_recalls_with_nontargeted_labels(data):
         data, grouped_targeted_labels, nontargeted_labels
     )
     assert len(actual) == 2
-    assert actual[0] == TicketScore(precisions=[], recalls=[],)
-    assert actual[1] == TicketScore(
+    assert actual[0] == TextScore(precisions=[], recalls=[],)
+    assert actual[1] == TextScore(
         precisions=[],
         recalls=[
             EntityRecall(Entity("ORGANIZATION", 15, 30), 0.0),

--- a/pii_recognition/pipelines/pii_validation_pipeline_test.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline_test.py
@@ -1,9 +1,17 @@
 from mock import patch
 from pii_recognition.data_readers.data import Data, DataItem
+from pii_recognition.evaluation.character_level_evaluation import (
+    TicketScore,
+    EntityPrecision,
+    EntityRecall,
+)
 from pii_recognition.labels.schema import Entity
 from pytest import fixture
 
-from .pii_validation_pipeline import identify_pii_entities
+from .pii_validation_pipeline import (
+    identify_pii_entities,
+    calculate_precisions_and_recalls,
+)
 
 
 @fixture
@@ -48,4 +56,68 @@ def test_identify_pii_entities(mock_registry, data):
     assert [item.pred_labels for item in data.items] == [
         [Entity("test", 0, 4)],
         [Entity("test", 0, 4)],
+    ]
+
+
+def test_calculate_precisions_and_recalls_with_no_predictions(data):
+    grouped_targeted_labels = [{"BIRTHDAY"}, {"ORGANIZATION"}, {"LOCATION"}]
+
+    actual = calculate_precisions_and_recalls(data, grouped_targeted_labels)
+    assert actual == [
+        TicketScore(
+            precisions=[], recalls=[EntityRecall(Entity("BIRTHDAY", 21, 31), 0.0)]
+        ),
+        TicketScore(
+            precisions=[],
+            recalls=[
+                EntityRecall(Entity("ORGANIZATION", 15, 30), 0.0),
+                EntityRecall(Entity("LOCATION", 34, 58), 0.0),
+            ],
+        ),
+    ]
+
+
+def test_calculate_precisions_and_recalls_with_predictions(data):
+    data.items[0].pred_labels = [Entity("BIRTHDAY", 21, 31)]
+    data.items[1].pred_labels = [
+        Entity("ORGANIZATION", 15, 30),
+        Entity("LOCATION", 34, 58),
+    ]
+    grouped_targeted_labels = [{"BIRTHDAY"}, {"ORGANIZATION"}, {"LOCATION"}]
+
+    actual = calculate_precisions_and_recalls(data, grouped_targeted_labels)
+    assert actual == [
+        TicketScore(
+            precisions=[EntityPrecision(Entity("BIRTHDAY", 21, 31), 1.0)],
+            recalls=[EntityRecall(Entity("BIRTHDAY", 21, 31), 1.0)],
+        ),
+        TicketScore(
+            precisions=[
+                EntityPrecision(Entity("ORGANIZATION", 15, 30), 1.0),
+                EntityPrecision(Entity("LOCATION", 34, 58), 1.0),
+            ],
+            recalls=[
+                EntityRecall(Entity("ORGANIZATION", 15, 30), 1.0),
+                EntityRecall(Entity("LOCATION", 34, 58), 1.0),
+            ],
+        ),
+    ]
+
+
+def test_calculate_precisions_and_recalls_with_nontargeted_labels(data):
+    grouped_targeted_labels = [{"ORGANIZATION"}, {"LOCATION"}]
+    nontargeted_labels = {"BIRTHDAY", "DATE"}
+
+    actual = calculate_precisions_and_recalls(
+        data, grouped_targeted_labels, nontargeted_labels
+    )
+    assert actual == [
+        TicketScore(precisions=[], recalls=[],),
+        TicketScore(
+            precisions=[],
+            recalls=[
+                EntityRecall(Entity("ORGANIZATION", 15, 30), 0.0),
+                EntityRecall(Entity("LOCATION", 34, 58), 0.0),
+            ],
+        ),
     ]

--- a/pii_recognition/pipelines/pii_validation_pipeline_test.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline_test.py
@@ -59,49 +59,47 @@ def test_identify_pii_entities(mock_registry, data):
     ]
 
 
-def test_calculate_precisions_and_recalls_with_no_predictions(data):
+def test_calculate_precisions_and_recalls_with_empty_predictions(data):
     grouped_targeted_labels = [{"BIRTHDAY"}, {"ORGANIZATION"}, {"LOCATION"}]
 
     actual = calculate_precisions_and_recalls(data, grouped_targeted_labels)
-    assert actual == [
-        TicketScore(
-            precisions=[], recalls=[EntityRecall(Entity("BIRTHDAY", 21, 31), 0.0)]
-        ),
-        TicketScore(
-            precisions=[],
-            recalls=[
-                EntityRecall(Entity("ORGANIZATION", 15, 30), 0.0),
-                EntityRecall(Entity("LOCATION", 34, 58), 0.0),
-            ],
-        ),
-    ]
+    assert len(actual) == 2
+    assert actual[0] == TicketScore(
+        precisions=[], recalls=[EntityRecall(Entity("BIRTHDAY", 21, 31), 0.0)]
+    )
+    assert actual[1] == TicketScore(
+        precisions=[],
+        recalls=[
+            EntityRecall(Entity("ORGANIZATION", 15, 30), 0.0),
+            EntityRecall(Entity("LOCATION", 34, 58), 0.0),
+        ],
+    )
 
 
 def test_calculate_precisions_and_recalls_with_predictions(data):
-    data.items[0].pred_labels = [Entity("BIRTHDAY", 21, 31)]
+    data.items[0].pred_labels = [Entity("BIRTHDAY", 0, 10)]
     data.items[1].pred_labels = [
-        Entity("ORGANIZATION", 15, 30),
-        Entity("LOCATION", 34, 58),
+        Entity("ORGANIZATION", 20, 30),
+        Entity("LOCATION", 30, 46),
     ]
     grouped_targeted_labels = [{"BIRTHDAY"}, {"ORGANIZATION"}, {"LOCATION"}]
 
     actual = calculate_precisions_and_recalls(data, grouped_targeted_labels)
-    assert actual == [
-        TicketScore(
-            precisions=[EntityPrecision(Entity("BIRTHDAY", 21, 31), 1.0)],
-            recalls=[EntityRecall(Entity("BIRTHDAY", 21, 31), 1.0)],
-        ),
-        TicketScore(
-            precisions=[
-                EntityPrecision(Entity("ORGANIZATION", 15, 30), 1.0),
-                EntityPrecision(Entity("LOCATION", 34, 58), 1.0),
-            ],
-            recalls=[
-                EntityRecall(Entity("ORGANIZATION", 15, 30), 1.0),
-                EntityRecall(Entity("LOCATION", 34, 58), 1.0),
-            ],
-        ),
-    ]
+    assert len(actual) == 2
+    assert actual[0] == TicketScore(
+        precisions=[EntityPrecision(Entity("BIRTHDAY", 0, 10), 0.0)],
+        recalls=[EntityRecall(Entity("BIRTHDAY", 21, 31), 0.0)],
+    )
+    assert actual[1] == TicketScore(
+        precisions=[
+            EntityPrecision(Entity("ORGANIZATION", 20, 30), 1.0),
+            EntityPrecision(Entity("LOCATION", 30, 46), 0.75),
+        ],
+        recalls=[
+            EntityRecall(Entity("ORGANIZATION", 15, 30), 2 / 3),
+            EntityRecall(Entity("LOCATION", 34, 58), 0.5),
+        ],
+    )
 
 
 def test_calculate_precisions_and_recalls_with_nontargeted_labels(data):
@@ -111,13 +109,12 @@ def test_calculate_precisions_and_recalls_with_nontargeted_labels(data):
     actual = calculate_precisions_and_recalls(
         data, grouped_targeted_labels, nontargeted_labels
     )
-    assert actual == [
-        TicketScore(precisions=[], recalls=[],),
-        TicketScore(
-            precisions=[],
-            recalls=[
-                EntityRecall(Entity("ORGANIZATION", 15, 30), 0.0),
-                EntityRecall(Entity("LOCATION", 34, 58), 0.0),
-            ],
-        ),
-    ]
+    assert len(actual) == 2
+    assert actual[0] == TicketScore(precisions=[], recalls=[],)
+    assert actual[1] == TicketScore(
+        precisions=[],
+        recalls=[
+            EntityRecall(Entity("ORGANIZATION", 15, 30), 0.0),
+            EntityRecall(Entity("LOCATION", 34, 58), 0.0),
+        ],
+    )


### PR DESCRIPTION
### Description
This is another pipeline step that calculates precisions and recalls via comparing ground truth and predictions. Here's the changes
1) Added dataclasses as the containers to hold precision and recall scores. The alternative is to use plain list which could be a deep nested structure. Tests are updated to reflect the change of data structure.
2) Added `build_label_mapping` function. This function is responsible for creating entity label to integer mapping.
3) Added the pipeline step for calculating precessions and recalls.

#### Checklist
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.