### PR TITLE
Add pipeline step -- rollup calculating f1 on PII recognition

### DIFF
--- a/pii_recognition/pipelines/pii_validation_pipeline.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Set, Optional
+from typing import Dict, List, Optional, Set
 
 from pakkr import returns
 from pii_recognition.data_readers.data import Data
@@ -8,6 +8,7 @@ from pii_recognition.evaluation.character_level_evaluation import (
     build_label_mapping,
     compute_entity_precisions_for_prediction,
     compute_entity_recalls_for_ground_truth,
+    compute_pii_detection_f1,
 )
 from pii_recognition.recognisers import registry as recogniser_registry
 from pii_recognition.recognisers.entity_recogniser import EntityRecogniser
@@ -57,3 +58,30 @@ def calculate_precisions_and_recalls(
         scores.append(ticket_score)
 
     return scores
+
+
+@returns(Dict)
+def calculate_aggregate_metrics(
+    scores: List[TextScore], f1_beta: float = 1.0
+) -> Dict[str, float]:
+    results = dict()
+    exact_match = get_rollup_f1s_on_pii(scores, f1_beta, recall_threshold=None)
+    results["exact_match_f1"] = sum(exact_match) / len(exact_match)
+
+    partial_match = get_rollup_f1s_on_pii(scores, f1_beta, recall_threshold=0.5)
+    results["partial_match_f1_threshold_at_50%"] = sum(partial_match) / len(
+        partial_match
+    )
+    return results
+
+
+def get_rollup_f1s_on_pii(
+    scores: List[TextScore], f1_beta: float, recall_threshold: Optional[float]
+) -> List[float]:
+    f1s = []
+    for text_score in scores:
+        precisions = [p.precision for p in text_score.precisions]
+        recalls = [r.recall for r in text_score.recalls]
+        f1 = compute_pii_detection_f1(precisions, recalls, recall_threshold, f1_beta)
+        f1s.append(f1)
+    return f1s

--- a/pii_recognition/pipelines/pii_validation_pipeline_test.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline_test.py
@@ -1,16 +1,18 @@
 from mock import patch
 from pii_recognition.data_readers.data import Data, DataItem
 from pii_recognition.evaluation.character_level_evaluation import (
-    TextScore,
     EntityPrecision,
     EntityRecall,
+    TextScore,
 )
 from pii_recognition.labels.schema import Entity
 from pytest import fixture
 
 from .pii_validation_pipeline import (
-    identify_pii_entities,
+    calculate_aggregate_metrics,
     calculate_precisions_and_recalls,
+    get_rollup_f1s_on_pii,
+    identify_pii_entities,
 )
 
 
@@ -33,27 +35,52 @@ def data():
     )
 
 
+@fixture
+def scores():
+    scores = []
+    scores.append(
+        TextScore(
+            precisions=[EntityPrecision(Entity("BIRTHDAY", 0, 10), 0.0)],
+            recalls=[EntityRecall(Entity("BIRTHDAY", 21, 31), 0.0)],
+        )
+    )
+    scores.append(
+        TextScore(
+            precisions=[
+                EntityPrecision(Entity("ORGANIZATION", 20, 30), 1.0),
+                EntityPrecision(Entity("LOCATION", 30, 46), 0.75),
+            ],
+            recalls=[
+                EntityRecall(Entity("ORGANIZATION", 15, 30), 2 / 3),
+                EntityRecall(Entity("LOCATION", 34, 58), 0.5),
+            ],
+        )
+    )
+
+    return scores
+
+
 @patch("pii_recognition.pipelines.pii_validation_pipeline.recogniser_registry")
 def test_identify_pii_entities(mock_registry, data):
     mock_registry.create_instance.return_value.analyse.return_value = [
         Entity("test", 0, 4)
     ]
 
-    data = identify_pii_entities(
+    actual = identify_pii_entities(
         data,
         "test_recogniser",
         {"supported_entities": ["test"], "supported_languages": ["test"]},
     )
 
-    assert [item.text for item in data.items] == [
+    assert [item.text for item in actual.items] == [
         "It's like that since 12/17/1967",
         "The address of Balefire Global is Valadouro 3, Ubide 48145",
     ]
-    assert [item.true_labels for item in data.items] == [
+    assert [item.true_labels for item in actual.items] == [
         [Entity("BIRTHDAY", 21, 31)],
         [Entity("ORGANIZATION", 15, 30), Entity("LOCATION", 34, 58)],
     ]
-    assert [item.pred_labels for item in data.items] == [
+    assert [item.pred_labels for item in actual.items] == [
         [Entity("test", 0, 4)],
         [Entity("test", 0, 4)],
     ]
@@ -118,3 +145,21 @@ def test_calculate_precisions_and_recalls_with_nontargeted_labels(data):
             EntityRecall(Entity("LOCATION", 34, 58), 0.0),
         ],
     )
+
+
+def test_get_rollup_f1s_on_pii_no_threshold(scores):
+    actual = get_rollup_f1s_on_pii(scores, f1_beta=1, recall_threshold=None)
+    assert actual == [0.0, 0.7]
+
+
+def test_get_rollup_f1s_on_pii_threshold(scores):
+    actual = get_rollup_f1s_on_pii(scores, f1_beta=1, recall_threshold=0.4)
+    assert actual == [0.0, 14 / 15]
+
+
+@patch("pii_recognition.pipelines.pii_validation_pipeline.get_rollup_f1s_on_pii")
+def test_calculate_aggregate_metrics(mock_pii_f1s):
+    mock_pii_f1s.return_value = [0.5, 0.5]
+
+    actual = calculate_aggregate_metrics([])
+    assert actual == {"exact_match_f1": 0.5, "partial_match_f1_threshold_at_50%": 0.5}


### PR DESCRIPTION
### Description
Another pipeline step that calculates a variety of metrics reflecting the system's performance on entity recognition.

Note there are many other metrics available, we could go back and visit those metrics once done the first iteration of the pipeline. For example, we can add metrics describing the performance on each entity type.

#### Checklist
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.