### PR TITLE
Bug fix - F1 calculations on empty precisions and/or recalls

### DIFF
--- a/pii_recognition/evaluation/character_level_evaluation.py
+++ b/pii_recognition/evaluation/character_level_evaluation.py
@@ -155,7 +155,7 @@ def compute_pii_detection_f1(
     precisions: List[float],
     recalls: List[float],
     recall_threshold: Optional[float] = None,
-    beta: float = 1
+    beta: float = 1,
 ) -> float:
     """Evaluate performance of PII detection with F1.
 
@@ -181,11 +181,17 @@ def compute_pii_detection_f1(
             )
 
     if not precisions and not recalls:
-        raise ValueError("You are passing empty precisions and recalls lists!")
+        # empty precisions and recalls mean that
+        # there is no true entity and the system predicts nothing
+        return 1.0
     if not precisions:
-        raise ValueError("You are passing empty precisions list!")
+        # empty precisions mean that
+        # there are true entities but the system predicts nothing
+        return 0.0
     elif not recalls:
-        raise ValueError("You are passing empty recalls list!")
+        # empty recalls mean that
+        # there is no true entity but the system predicts something
+        return 0.0
 
     if recall_threshold:
         recalls = [1.0 if item >= recall_threshold else item for item in recalls]

--- a/pii_recognition/evaluation/character_level_evaluation_test.py
+++ b/pii_recognition/evaluation/character_level_evaluation_test.py
@@ -429,21 +429,18 @@ def test_compute_pii_detection_f1_for_invalid_threshold():
 
 
 def test_compute_pii_detection_f1_for_empty_precisions():
-    with pytest.raises(ValueError) as err:
-        compute_pii_detection_f1([], [0.0], recall_threshold=0.5)
-    assert str(err.value) == "You are passing empty precisions list!"
+    actual = compute_pii_detection_f1([], [0.0])
+    assert actual == 0.0
 
 
 def test_compute_pii_detection_f1_for_empty_recalls():
-    with pytest.raises(ValueError) as err:
-        compute_pii_detection_f1([0.0], [], recall_threshold=0.5)
-    assert str(err.value) == "You are passing empty recalls list!"
+    actual = compute_pii_detection_f1([0.0], [])
+    assert actual == 0.0
 
 
 def test_compute_pii_detection_f1_for_empty_precisions_recalls():
-    with pytest.raises(ValueError) as err:
-        compute_pii_detection_f1([], [], recall_threshold=0.5)
-    assert str(err.value) == "You are passing empty precisions and recalls lists!"
+    actual = compute_pii_detection_f1([], [])
+    assert actual == 1.0
 
 
 def test_build_label_mapping_with_nontargeted_labels():
@@ -459,3 +456,47 @@ def test_build_label_mapping_without_nontargeted_labels():
 
     actual = build_label_mapping(grouped_targeted_labels)
     assert actual == {"PERSON": 1, "PER": 1, "LOCATION": 2, "DATE": 3}
+
+
+def test_compute_entity_precisions_for_prediction_no_true_entities():
+    actual = compute_entity_precisions_for_prediction(
+        50, [], [Entity("PER", 5, 10), Entity("LOC", 15, 25)], {"PER": 1, "LOC": 2}
+    )
+    assert actual == [
+        EntityPrecision(Entity("PER", 5, 10), 0.0),
+        EntityPrecision(Entity("LOC", 15, 25), 0.0),
+    ]
+
+
+def test_compute_entity_precisions_for_prediction_no_pred_entities():
+    actual = compute_entity_precisions_for_prediction(
+        50, [Entity("PER", 5, 10), Entity("LOC", 15, 25)], [], {"PER": 1, "LOC": 2}
+    )
+    assert actual == []
+
+
+def test_compute_entity_precisions_for_prediction_no_true_no_pred_entities():
+    actual = compute_entity_precisions_for_prediction(50, [], [], {"PER": 1, "LOC": 2})
+    assert actual == []
+
+
+def test_compute_entity_recalls_for_ground_truth_no_true_entities():
+    actual = compute_entity_recalls_for_ground_truth(
+        50, [], [Entity("PER", 5, 10), Entity("LOC", 15, 25)], {"PER": 1, "LOC": 2}
+    )
+    assert actual == []
+
+
+def test_compute_entity_recalls_for_ground_truth_no_pred_entities():
+    actual = compute_entity_recalls_for_ground_truth(
+        50, [Entity("PER", 5, 10), Entity("LOC", 15, 25)], [], {"PER": 1, "LOC": 2}
+    )
+    assert actual == [
+        EntityRecall(Entity("PER", 5, 10), 0.0),
+        EntityRecall(Entity("LOC", 15, 25), 0.0),
+    ]
+
+
+def test_compute_entity_recalls_for_ground_truth_no_true_pred_entities():
+    actual = compute_entity_recalls_for_ground_truth(50, [], [], {"PER": 1, "LOC": 2})
+    assert actual == []


### PR DESCRIPTION
### Description
Previously if we encounter empty precisions and/or recalls when calculating F1, an error will be raised. We will have to handle the errors conditionally. However, we do not need to raise errors, the situations can be handled by hard assigning F1 with different values.

1. Add these logics to scoring empty lists on F1 calculations
    1. There are true entities but the system predicts nothing (empty precisions) --> f1 = 0.0
    2. There is no true entity but the system predicts something (empty recalls) --> f1 = 0.0
    3. There is no true entity and the system predicts nothing (empty precisions and recalls) --> f1 = 1.0

#### Checklist
- [x] Added **tests** for changed code.
