### PR TITLE
Refactor -- simplify f1 calculation on PII recognition

### DIFF
--- a/pii_recognition/evaluation/character_level_evaluation.py
+++ b/pii_recognition/evaluation/character_level_evaluation.py
@@ -167,8 +167,8 @@ def compute_pii_detection_f1(
     Args:
         precisions: a list of entity precision values.
         recalls: a list of entity recall values.
-        recall_threshold: a float between 0 and 1. Any value greater than or equals
-            to the threshold would be rounded up to 1.
+        recall_threshold: a float between 0 and 1. Any recall value that is greater
+            than or equals to the threshold would be rounded up to 1.
 
     Returns:
         F1 score.

--- a/pii_recognition/evaluation/character_level_evaluation.py
+++ b/pii_recognition/evaluation/character_level_evaluation.py
@@ -151,15 +151,15 @@ def compute_entity_recalls_for_ground_truth(
     return recalls
 
 
-def compute_pii_detection_f1(
+def compute_pii_detection_fscore(
     precisions: List[float],
     recalls: List[float],
     recall_threshold: Optional[float] = None,
     beta: float = 1,
 ) -> float:
-    """Evaluate performance of PII detection with F1.
+    """Evaluate performance of PII detection with F score.
 
-    Rollup precisions and recalls to calculate F1 on boundary detection for PII
+    Rollup precisions and recalls to calculate F score on boundary detection for PII
     recognition. Recall thresholding is supported, if the system can recognise
     a certain portion of an entity beyond the threshold, we will consider it a
     success.
@@ -171,7 +171,7 @@ def compute_pii_detection_f1(
             than or equals to the threshold would be rounded up to 1.
 
     Returns:
-        F1 score.
+        F score.
     """
     if recall_threshold:
         if recall_threshold > 1.0 or recall_threshold < 0.0:

--- a/pii_recognition/evaluation/character_level_evaluation.py
+++ b/pii_recognition/evaluation/character_level_evaluation.py
@@ -155,7 +155,7 @@ def compute_pii_detection_f1(
     precisions: List[float],
     recalls: List[float],
     recall_threshold: Optional[float] = None,
-    beta: float = 1
+    beta: float = 1,
 ) -> float:
     """Evaluate performance of PII detection with F1.
 

--- a/pii_recognition/evaluation/character_level_evaluation_test.py
+++ b/pii_recognition/evaluation/character_level_evaluation_test.py
@@ -6,7 +6,7 @@ from pii_recognition.evaluation.character_level_evaluation import (
     build_label_mapping,
     compute_entity_precisions_for_prediction,
     compute_entity_recalls_for_ground_truth,
-    compute_pii_detection_f1,
+    compute_pii_detection_fscore,
     label_encoder,
     EntityRecall,
     EntityPrecision,
@@ -391,55 +391,55 @@ def test_compute_precisions_recalls_for_no_true():
     assert recalls == []
 
 
-def test_compute_pii_detection_f1_for_no_recall_threshold_f1_is_one():
+def test_compute_pii_detection_fscore_for_no_recall_threshold_fscore_is_one():
     precisions = [1.0, 1.0]
     recalls = [1.0, 1.0]
-    actual = compute_pii_detection_f1(precisions, recalls)
+    actual = compute_pii_detection_fscore(precisions, recalls)
     assert actual == 1.0
 
 
-def test_compute_pii_detection_f1_for_no_recall_threshold_f1_is_zero():
+def test_compute_pii_detection_fscore_for_no_recall_threshold_fscore_is_zero():
     precisions = [0.0, 0.0]
     recalls = [0.0, 0.0]
-    actual = compute_pii_detection_f1(precisions, recalls)
+    actual = compute_pii_detection_fscore(precisions, recalls)
     assert actual == 0.0
 
 
-def test_compute_pii_detection_f1_for_no_recall_threshold():
+def test_compute_pii_detection_fscore_for_no_recall_threshold():
     precisions = [0.4, 0.8]
     recalls = [0.2, 0.7]
-    actual = compute_pii_detection_f1(precisions, recalls)
+    actual = compute_pii_detection_fscore(precisions, recalls)
     assert_almost_equal(actual, 0.5142857)
 
 
-def test_compute_pii_detection_f1_with_recall_threshold():
+def test_compute_pii_detection_fscore_with_recall_threshold():
     precisions = [0.4, 0.8, 0.9]
     recalls = [0.2, 0.51, 0.7]
-    actual = compute_pii_detection_f1(precisions, recalls, recall_threshold=0.5)
+    actual = compute_pii_detection_fscore(precisions, recalls, recall_threshold=0.5)
     assert_almost_equal(actual, 0.716279)
 
 
-def test_compute_pii_detection_f1_for_invalid_threshold():
+def test_compute_pii_detection_fscore_for_invalid_threshold():
     precisions = recalls = [0.0]
     with pytest.raises(ValueError) as err:
-        compute_pii_detection_f1(precisions, recalls, recall_threshold=2.0)
+        compute_pii_detection_fscore(precisions, recalls, recall_threshold=2.0)
     assert str(err.value) == (
         "Invalid threshold! Recall threshold must between 0 and 1 but got 2.0"
     )
 
 
-def test_compute_pii_detection_f1_for_empty_precisions():
-    actual = compute_pii_detection_f1([], [0.0])
+def test_compute_pii_detection_fscore_for_empty_precisions():
+    actual = compute_pii_detection_fscore([], [0.0])
     assert actual == 0.0
 
 
-def test_compute_pii_detection_f1_for_empty_recalls():
-    actual = compute_pii_detection_f1([0.0], [])
+def test_compute_pii_detection_fscore_for_empty_recalls():
+    actual = compute_pii_detection_fscore([0.0], [])
     assert actual == 0.0
 
 
-def test_compute_pii_detection_f1_for_empty_precisions_recalls():
-    actual = compute_pii_detection_f1([], [])
+def test_compute_pii_detection_fscore_for_empty_precisions_recalls():
+    actual = compute_pii_detection_fscore([], [])
     assert actual == 1.0
 
 

--- a/pii_recognition/pipelines/pii_validation_pipeline.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline.py
@@ -8,7 +8,7 @@ from pii_recognition.evaluation.character_level_evaluation import (
     build_label_mapping,
     compute_entity_precisions_for_prediction,
     compute_entity_recalls_for_ground_truth,
-    compute_pii_detection_f1,
+    compute_pii_detection_fscore,
 )
 from pii_recognition.recognisers import registry as recogniser_registry
 from pii_recognition.recognisers.entity_recogniser import EntityRecogniser
@@ -103,7 +103,7 @@ def get_rollup_fscore_on_pii(
     for text_score in scores:
         precisions = [p.precision for p in text_score.precisions]
         recalls = [r.recall for r in text_score.recalls]
-        f = compute_pii_detection_f1(precisions, recalls, recall_threshold, fbeta)
+        f = compute_pii_detection_fscore(precisions, recalls, recall_threshold, fbeta)
         fscores.append(f)
 
     if fbeta:

--- a/pii_recognition/pipelines/pii_validation_pipeline.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline.py
@@ -71,11 +71,11 @@ def calculate_aggregate_metrics(
 ) -> Dict[str, float]:
     round_ndigits = 4
     results = dict()
-    results["exact_match_f1"] = round(get_rollup_fscore_on_pii(
-        scores, fbeta, recall_threshold=None), round_ndigits
+    results["exact_match_f1"] = round(
+        get_rollup_fscore_on_pii(scores, fbeta, recall_threshold=None), round_ndigits
     )
-    results["partial_match_f1_threshold_at_50%"] = round(get_rollup_fscore_on_pii(
-        scores, fbeta, recall_threshold=0.5), round_ndigits
+    results["partial_match_f1_threshold_at_50%"] = round(
+        get_rollup_fscore_on_pii(scores, fbeta, recall_threshold=0.5), round_ndigits
     )
     return results
 
@@ -111,7 +111,7 @@ def get_rollup_fscore_on_pii(
         f = compute_pii_detection_fscore(precisions, recalls, recall_threshold, fbeta)
         fscores.append(f)
 
-    if fbeta:
+    if fscores:
         return sum(fscores) / len(fscores)
     else:
         # The only possibility to have empty fscores is that argument "scores"

--- a/pii_recognition/pipelines/pii_validation_pipeline.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline.py
@@ -109,6 +109,6 @@ def get_rollup_f1_on_pii(
     if f1s:
         return sum(f1s) / len(f1s)
     else:
-        # The only possibility to have empty f1s is that arguemtn "scores"
+        # The only possibility to have empty f1s is that argument "scores"
         # is empty. In this case, we assign f score to 0.
         return 0.0

--- a/pii_recognition/pipelines/pii_validation_pipeline.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline.py
@@ -63,14 +63,14 @@ def calculate_precisions_and_recalls(
 
 @returns(Dict)
 def calculate_aggregate_metrics(
-    scores: List[TextScore], f1_beta: float = 1.0
+    scores: List[TextScore], fbeta: float = 1.0
 ) -> Dict[str, float]:
     results = dict()
-    results["exact_match_f1"] = get_rollup_f1_on_pii(
-        scores, f1_beta, recall_threshold=None
+    results["exact_match_f1"] = get_rollup_fscore_on_pii(
+        scores, fbeta, recall_threshold=None
     )
-    results["partial_match_f1_threshold_at_50%"] = get_rollup_f1_on_pii(
-        scores, f1_beta, recall_threshold=None
+    results["partial_match_f1_threshold_at_50%"] = get_rollup_fscore_on_pii(
+        scores, fbeta, recall_threshold=None
     )
     return results
 
@@ -80,8 +80,8 @@ def report_results(results: Dict[str, float], dump_file: str):
     dump_to_json_file(results, dump_file)
 
 
-def get_rollup_f1_on_pii(
-    scores: List[TextScore], f1_beta: float, recall_threshold: Optional[float]
+def get_rollup_fscore_on_pii(
+    scores: List[TextScore], fbeta: float, recall_threshold: Optional[float]
 ) -> float:
     """Calculate f score on PII recognition.
 
@@ -92,23 +92,23 @@ def get_rollup_f1_on_pii(
 
     Args:
         scores: a list of text scores providing info including precisions and recalls.
-        f1_beta: beta value for f score.
+        fbeta: beta value for f score.
         recall_threshold: a float between 0 and 1. Any recall value that is greater
             than or equals to the threshold would be rounded up to 1.
 
     Returns:
         A f score represents performance of a system.
     """
-    f1s = []
+    fscores = []
     for text_score in scores:
         precisions = [p.precision for p in text_score.precisions]
         recalls = [r.recall for r in text_score.recalls]
-        f1 = compute_pii_detection_f1(precisions, recalls, recall_threshold, f1_beta)
-        f1s.append(f1)
+        f = compute_pii_detection_f1(precisions, recalls, recall_threshold, fbeta)
+        fscores.append(f)
 
-    if f1s:
-        return sum(f1s) / len(f1s)
+    if fbeta:
+        return sum(fscores) / len(fscores)
     else:
-        # The only possibility to have empty f1s is that argument "scores"
+        # The only possibility to have empty fscores is that argument "scores"
         # is empty. In this case, we assign f score to 0.
         return 0.0

--- a/pii_recognition/pipelines/pii_validation_pipeline.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline.py
@@ -110,5 +110,5 @@ def get_rollup_f1_on_pii(
         return sum(f1s) / len(f1s)
     else:
         # The only possibility to have empty f1s is that arguemtn "scores"
-        # is empty. In this case, we assign it to 0.
+        # is empty. In this case, we assign f score to 0.
         return 0.0

--- a/pii_recognition/pipelines/pii_validation_pipeline_test.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline_test.py
@@ -11,7 +11,7 @@ from pytest import fixture
 from .pii_validation_pipeline import (
     calculate_aggregate_metrics,
     calculate_precisions_and_recalls,
-    get_rollup_f1s_on_pii,
+    get_rollup_f1_on_pii,
     identify_pii_entities,
 )
 
@@ -147,19 +147,19 @@ def test_calculate_precisions_and_recalls_with_nontargeted_labels(data):
     )
 
 
-def test_get_rollup_f1s_on_pii_no_threshold(scores):
-    actual = get_rollup_f1s_on_pii(scores, f1_beta=1, recall_threshold=None)
-    assert actual == [0.0, 0.7]
+def test_get_rollup_f1_on_pii_no_threshold(scores):
+    actual = get_rollup_f1_on_pii(scores, f1_beta=1, recall_threshold=None)
+    assert actual == 0.35
 
 
-def test_get_rollup_f1s_on_pii_threshold(scores):
-    actual = get_rollup_f1s_on_pii(scores, f1_beta=1, recall_threshold=0.4)
-    assert actual == [0.0, 14 / 15]
+def test_get_rollup_f1_on_pii_threshold(scores):
+    actual = get_rollup_f1_on_pii(scores, f1_beta=1, recall_threshold=0.4)
+    assert actual == 7 / 15
 
 
-@patch("pii_recognition.pipelines.pii_validation_pipeline.get_rollup_f1s_on_pii")
-def test_calculate_aggregate_metrics(mock_pii_f1s):
-    mock_pii_f1s.return_value = [0.5, 0.5]
+# @patch("pii_recognition.pipelines.pii_validation_pipeline.get_rollup_f1_on_pii")
+# def test_calculate_aggregate_metrics(mock_pii_f1s):
+#     mock_pii_f1s.return_value = [0.5, 0.5]
 
-    actual = calculate_aggregate_metrics([])
-    assert actual == {"exact_match_f1": 0.5, "partial_match_f1_threshold_at_50%": 0.5}
+#     actual = calculate_aggregate_metrics([])
+#     assert actual == {"exact_match_f1": 0.5, "partial_match_f1_threshold_at_50%": 0.5}

--- a/pii_recognition/pipelines/pii_validation_pipeline_test.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline_test.py
@@ -10,7 +10,7 @@ from pytest import fixture
 
 from .pii_validation_pipeline import (
     calculate_precisions_and_recalls,
-    get_rollup_f1_on_pii,
+    get_rollup_fscore_on_pii,
     identify_pii_entities,
 )
 
@@ -146,11 +146,11 @@ def test_calculate_precisions_and_recalls_with_nontargeted_labels(data):
     )
 
 
-def test_get_rollup_f1_on_pii_no_threshold(scores):
-    actual = get_rollup_f1_on_pii(scores, f1_beta=1, recall_threshold=None)
+def test_get_rollup_fscore_on_pii_no_threshold(scores):
+    actual = get_rollup_fscore_on_pii(scores, fbeta=1, recall_threshold=None)
     assert actual == 0.35
 
 
-def test_get_rollup_f1_on_pii_threshold(scores):
-    actual = get_rollup_f1_on_pii(scores, f1_beta=1, recall_threshold=0.4)
+def test_get_rollup_fscore_on_pii_threshold(scores):
+    actual = get_rollup_fscore_on_pii(scores, fbeta=1, recall_threshold=0.4)
     assert actual == 7 / 15

--- a/pii_recognition/pipelines/pii_validation_pipeline_test.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline_test.py
@@ -9,7 +9,6 @@ from pii_recognition.labels.schema import Entity
 from pytest import fixture
 
 from .pii_validation_pipeline import (
-    calculate_aggregate_metrics,
     calculate_precisions_and_recalls,
     get_rollup_f1_on_pii,
     identify_pii_entities,
@@ -155,11 +154,3 @@ def test_get_rollup_f1_on_pii_no_threshold(scores):
 def test_get_rollup_f1_on_pii_threshold(scores):
     actual = get_rollup_f1_on_pii(scores, f1_beta=1, recall_threshold=0.4)
     assert actual == 7 / 15
-
-
-# @patch("pii_recognition.pipelines.pii_validation_pipeline.get_rollup_f1_on_pii")
-# def test_calculate_aggregate_metrics(mock_pii_f1s):
-#     mock_pii_f1s.return_value = [0.5, 0.5]
-
-#     actual = calculate_aggregate_metrics([])
-#     assert actual == {"exact_match_f1": 0.5, "partial_match_f1_threshold_at_50%": 0.5}


### PR DESCRIPTION
### Description
Previously, the calculation of f1 on PII recognition happens in two places meaning we would have some unnecessary steps just to pass results from one function to another. This PR aims to remove the unnecessities.

#### Checklist
- [x] Added **tests** for changed code.