### PR TITLE
JSON dump to log mistakes made in predictions

### DIFF
--- a/pii_recognition/evaluation/character_level_evaluation.py
+++ b/pii_recognition/evaluation/character_level_evaluation.py
@@ -25,6 +25,7 @@ class EntityRecall:
 
 @dataclass
 class TextScore:
+    text: str
     precisions: List[EntityPrecision]
     recalls: List[EntityRecall]
 

--- a/pii_recognition/experiments/pii_validation/comprehend_ner.yaml
+++ b/pii_recognition/experiments/pii_validation/comprehend_ner.yaml
@@ -38,5 +38,6 @@ nontargeted_labels:
   - EVENT
   - QUANTITY
   - COMMERCIAL_ITEM
-dump_file: pii_recognition/experiments/pii_validation/reports/comprehend_ner_scores.json
+mistakes_dump_path: pii_recognition/experiments/pii_validation/comprehend_reports/mistakes_ner.json
+scores_dump_path: pii_recognition/experiments/pii_validation/comprehend_reports/scores_ner.json
 fbeta: 1.0

--- a/pii_recognition/experiments/pii_validation/comprehend_pii.yaml
+++ b/pii_recognition/experiments/pii_validation/comprehend_pii.yaml
@@ -72,5 +72,6 @@ nontargeted_labels:
   - PASSWORD
   - PASSPORT_NUMBER
   - DRIVER_ID
-dump_file: pii_recognition/experiments/pii_validation/reports/comprehend_pii_scores.json
+mistakes_dump_path: pii_recognition/experiments/pii_validation/comprehend_reports/mistakes_pii.json
+scores_dump_path: pii_recognition/experiments/pii_validation/comprehend_reports/scores_pii.json
 fbeta: 1.0

--- a/pii_recognition/experiments/pii_validation/spacy.yaml
+++ b/pii_recognition/experiments/pii_validation/spacy.yaml
@@ -64,5 +64,6 @@ nontargeted_labels:
   - PRODUCT
   - QUANTITY
   - WORK_OF_ART
-dump_file: pii_recognition/experiments/pii_validation/reports/spacy_scores.json
+mistakes_dump_path: pii_recognition/experiments/pii_validation/spacy_reports/mistakes_en_core_web_lg.json
+scores_dump_path: pii_recognition/experiments/pii_validation/spacy_reports/scores_en_core_web_lg.json
 fbeta: 1.0 

--- a/pii_recognition/pipelines/pii_validation_pipeline_test.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline_test.py
@@ -96,7 +96,8 @@ def complex_scores():
         )
     )
 
-    # 3. test types occurred in multiple texts i.e. LOCATION
+    # 3. test multiple occurrences of a type i.e. LOCATION it occurs in
+    # case 4 and 5 as well, this will test calculation on aggregated scores.
     scores.append(
         TextScore(
             text=(

--- a/pii_recognition/pipelines/pii_validation_pipeline_test.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline_test.py
@@ -282,7 +282,6 @@ def test_log_mistakes(scores):
         "9/23/1993": {"type": "BIRTHDAY", "score": 0.0, "src": "ground_truth"},
     }
     assert actual["The address of Balefire Global is Valadouro 3, Ubide 48145"] == {
-        "ire Global": {"type": "ORGANIZATION", "score": 1.0, "src": "predicted"},
         " is Valadouro 3,": {"type": "LOCATION", "score": 0.75, "src": "predicted"},
         "Balefire Global": {
             "type": "ORGANIZATION",

--- a/pii_recognition/utils.py
+++ b/pii_recognition/utils.py
@@ -51,6 +51,7 @@ def load_json_file(path: str):
 
 # Any is not a precise signature but it's ergonomic in practice
 def dump_to_json_file(obj: Any, path: str):
+    # TODO: enable write to directories that do not exist
     with open(path, "w") as f:
         json.dump(obj, f)
 

--- a/pii_recognition/utils.py
+++ b/pii_recognition/utils.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Type
+from typing import Any, Dict, Iterable, Optional, Sequence, Type
 
 import yaml
 
@@ -42,7 +42,9 @@ def dump_yaml_file(path: str, data: Any):
         yaml.dump(data, stream)
 
 
-def load_json_file(path: str) -> List[Dict]:
+# Type hint for json.load has not been supported because of recursive types
+# found details here https://github.com/python/typing/issues/182
+def load_json_file(path: str):
     with open(path, "r") as f:
         return json.load(f)
 

--- a/tests/assets/config/pii_validation.yaml
+++ b/tests/assets/config/pii_validation.yaml
@@ -19,5 +19,6 @@ nontargeted_labels:
   - EVENT
   - TITLE
   - ORGANIZATION
-dump_file: pii_recognition/experiments/pii_validation/reports/comprehend_scores.json
+mistakes_dump_path: placehoder
+scores_dump_path: placehoder
 f1_beta: 1.0

--- a/tests/integration_test/pii_validation_pipeline_test.py
+++ b/tests/integration_test/pii_validation_pipeline_test.py
@@ -52,21 +52,30 @@ def test_execute_pii_validation_pipeline(mock_registry):
     with TemporaryDirectory() as tempdir:
         # direct file writings to temp dir
         temp_config_yaml = os.path.join(tempdir, "config.yaml")
-        temp_json_dump = os.path.join(tempdir, "test_report.json")
 
         config = load_yaml_file(config_yaml)
-        config["dump_file"] = temp_json_dump
+        config["mistakes_dump_path"] = os.path.join(
+            tempdir, "test_mistakes.json"
+        )
+        config["scores_dump_path"] = scores_dump_path = os.path.join(
+            tempdir, "test_scores.json"
+        )
         dump_yaml_file(temp_config_yaml, config)
 
         exec_pipeline(temp_config_yaml)
-        report = load_json_file(temp_json_dump)
-        assert set(os.listdir(tempdir)) == {"config.yaml", "test_report.json"}
-        assert len(report.keys()) == 5
-        assert report["exact_match_f1"] == 0.5062
-        assert report["partial_match_f1_threshold_at_50%"] == 0.5333
-        assert report["frozenset({'PERSON'})"] == 0.4
-        assert report["frozenset({'LOCATION'})"] == 0.6857
+        scores = load_json_file(scores_dump_path)
+
+        assert set(os.listdir(tempdir)) == {
+            "config.yaml",
+            "test_mistakes.json",
+            "test_scores.json",
+        }
+        assert len(scores.keys()) == 5
+        assert scores["exact_match_f1"] == 0.5062
+        assert scores["partial_match_f1_threshold_at_50%"] == 0.5333
+        assert scores["frozenset({'PERSON'})"] == 0.4
+        assert scores["frozenset({'LOCATION'})"] == 0.6857
         assert (
-            report["frozenset({'CREDIT_CARD', 'OTHER'})"] == 1.0
-            or report["frozenset({'OTHER', 'CREDIT_CARD'})"] == 1.0
+            scores.get("frozenset({'CREDIT_CARD', 'OTHER'})") == 1.0
+            or scores.get("frozenset({'OTHER', 'CREDIT_CARD'})") == 1.0
         )


### PR DESCRIPTION
### Description
A pipeline step has been created to log mistakes made by a PII model. It helps understand where and why a PII model is failing. These have been changed:

* Added `Text` field to `TextScore`. This helps us track the original sentence and allows to reconstruct the entity in text.
* Update tests because of schema change on `TextScore`.
* Added `log_mistakes` step to pipeline. What it does is read scores and find mistakes and dump mistakes to file.
* Added test for `log_mistakes`.
* Update type-hint due to a failure on `json.load()`
* Update config yaml of pipeline that adds dumpping destination for logging mistakes.

#### Checklist
- [x] Added **tests** for changed code.
