### PR TITLE
Fixing bugs -- avoid modifying dict while iterating on it 

### DIFF
--- a/pii_recognition/experiments/pii_validation/comprehend_ner.yaml
+++ b/pii_recognition/experiments/pii_validation/comprehend_ner.yaml
@@ -23,6 +23,7 @@ grouped_targeted_labels:
     - CREDIT_CARD
     - URL
     - EMAIL
+    - IBAN
   - 
     - BIRTHDAY
     - DATE
@@ -31,10 +32,11 @@ grouped_targeted_labels:
   - 
     - PERSON
 nontargeted_labels:
+  # benchmark entities being removed
   - TITLE
   - ORGANIZATION
-  - IBAN
   - NATIONALITY
+  # comprehend entities being removed
   - EVENT
   - QUANTITY
   - COMMERCIAL_ITEM

--- a/pii_recognition/experiments/pii_validation/comprehend_pii.yaml
+++ b/pii_recognition/experiments/pii_validation/comprehend_pii.yaml
@@ -30,12 +30,14 @@ recogniser_params:
 grouped_targeted_labels:
   - 
     - CREDIT_CARD
-    - BANK_ACCOUNT_NUMBER
     - BANK_ROUTING
     - CREDIT_DEBIT_NUMBER
     - CREDIT_DEBIT_CVV
     - CREDIT_DEBIT_EXPIRY
     - PIN
+  -
+    - IBAN
+    - BANK_ACCOUNT_NUMBER
   - 
     - US_SSN
     - SSN
@@ -62,7 +64,6 @@ grouped_targeted_labels:
 nontargeted_labels:
   # benchmark entities being removed
   - NATIONALITY
-  - IBAN
   - TITLE
   - ORGANIZATION
   # comprehend entities being removed

--- a/pii_recognition/experiments/pii_validation/spacy.yaml
+++ b/pii_recognition/experiments/pii_validation/spacy.yaml
@@ -32,6 +32,7 @@ grouped_targeted_labels:
     - CREDIT_CARD
     - US_SSN
     - PHONE_NUMBER
+    - IBAN
     - CARDINAL
   -
     - LOCATION
@@ -48,7 +49,6 @@ grouped_targeted_labels:
 nontargeted_labels:
   # benchmark labels being removed
   - NATIONALITY
-  - IBAN
   - TITLE
   - ORGANIZATION
   # Spacy labels being removed

--- a/pii_recognition/recognisers/comprehend_recogniser.py
+++ b/pii_recognition/recognisers/comprehend_recogniser.py
@@ -56,6 +56,7 @@ class ComprehendRecogniser(EntityRecogniser):
         DEFAULT_LANG = "en"
 
         response = self.model_func(Text=text, LanguageCode=DEFAULT_LANG)
+        import pdb; pdb.set_trace()
 
         # parse response
         predicted_entities = response["Entities"]

--- a/pii_recognition/recognisers/comprehend_recogniser.py
+++ b/pii_recognition/recognisers/comprehend_recogniser.py
@@ -56,7 +56,6 @@ class ComprehendRecogniser(EntityRecogniser):
         DEFAULT_LANG = "en"
 
         response = self.model_func(Text=text, LanguageCode=DEFAULT_LANG)
-        import pdb; pdb.set_trace()
 
         # parse response
         predicted_entities = response["Entities"]

--- a/pii_recognition/utils.py
+++ b/pii_recognition/utils.py
@@ -59,12 +59,14 @@ def dump_to_json_file(obj: Any, path: str):
 def stringify_keys(data: Dict) -> Dict[str, Any]:
     stringify_dict = dict()
     for key, value in data.items():
-        if isinstance(value, dict):
-            stringify_dict[key] = stringify_keys(value)
-
         if not isinstance(key, str):
-            stringify_dict[str(key)] = value
+            new_key = str(key)
         else:
-            stringify_dict[key] = value
+            new_key = key
+
+        if isinstance(value, dict):
+            stringify_dict[new_key] = stringify_keys(value)
+        else:
+            stringify_dict[new_key] = value
 
     return stringify_dict

--- a/pii_recognition/utils.py
+++ b/pii_recognition/utils.py
@@ -57,11 +57,14 @@ def dump_to_json_file(obj: Any, path: str):
 
 
 def stringify_keys(data: Dict) -> Dict[str, Any]:
+    stringify_dict = dict()
     for key, value in data.items():
         if isinstance(value, dict):
-            data[key] = stringify_keys(value)
+            stringify_dict[key] = stringify_keys(value)
 
         if not isinstance(key, str):
-            data[str(key)] = value
-            del data[key]
-    return data
+            stringify_dict[str(key)] = value
+        else:
+            stringify_dict[key] = value
+
+    return stringify_dict


### PR DESCRIPTION
### Description
When writing up reports and running the validation pipelines, two bugs were identified.

1. Grouping. IBAN was ignore from score calculation but it is actually a PII entity. So added it back.
2. Modifying dict being iterated on. This is not safe and could cause unexpected behavior. Learn more from [here](https://stackoverflow.com/questions/3346696/why-is-it-not-safe-to-modify-sequence-being-iterated-on).

#### Checklist
- [X] Added **tests** for changed code.
