### PR TITLE
Add Google Cloud natural language models to validation pipeline

### DIFF
--- a/pii_recognition/experiments/pii_validation/google_cloud.yaml
+++ b/pii_recognition/experiments/pii_validation/google_cloud.yaml
@@ -19,14 +19,13 @@ recogniser_params:
     - en
 grouped_targeted_labels:
   - 
-   - CREDIT_CARD
-   - URL
-   - IP_ADDRESS
-   - IBAN
-   - EMAIL
-   - OTHER
+    - CREDIT_CARD
+    - EMAIL
+    - OTHER
   -
     - US_SSN
+    - IBAN
+    - IP_ADDRESS
     - NUMBER
   -
     - BIRTHDAY
@@ -38,6 +37,9 @@ grouped_targeted_labels:
     - ADDRESS
   -
     - PERSON
+  -
+    # checked, URL is not in the model's OTHER category
+    - URL
 nontargeted_labels:
   # benchmark entities being removed
   - NATIONALITY

--- a/pii_recognition/experiments/pii_validation/google_cloud.yaml
+++ b/pii_recognition/experiments/pii_validation/google_cloud.yaml
@@ -19,13 +19,13 @@ recogniser_params:
     - en
 grouped_targeted_labels:
   - 
-    - CREDIT_CARD
     - EMAIL
     - OTHER
   -
     - US_SSN
     - IBAN
     - IP_ADDRESS
+    - CREDIT_CARD
     - NUMBER
   -
     - BIRTHDAY

--- a/pii_recognition/experiments/pii_validation/google_cloud.yaml
+++ b/pii_recognition/experiments/pii_validation/google_cloud.yaml
@@ -1,0 +1,54 @@
+benchmark_data_file: pii_recognition/datasets/predisio_fake_pii/generated_size_500_date_August_25_2020.json
+recogniser_name: GoogleRecogniser
+recogniser_params:
+  supported_entities:
+    - UNKNOWN
+    - PERSON
+    - LOCATION
+    - ORGANIZATION
+    - EVENT
+    - WORK_OF_ART
+    - CONSUMER_GOOD
+    - OTHER
+    - PHONE_NUMBER
+    - ADDRESS
+    - DATE
+    - NUMBER
+    - PRICE
+  supported_languages: 
+    - en
+grouped_targeted_labels:
+  - 
+   - CREDIT_CARD
+   - URL
+   - IP_ADDRESS
+   - IBAN
+   - EMAIL
+   - OTHER
+  -
+    - US_SSN
+    - NUMBER
+  -
+    - BIRTHDAY
+    - DATE
+  -
+    - PHONE_NUMBER
+  -
+    - LOCATION
+    - ADDRESS
+  -
+    - PERSON
+nontargeted_labels:
+  # benchmark entities being removed
+  - NATIONALITY
+  - TITLE
+  - ORGANIZATION
+  # comprehend entities being removed
+  - UNKNOWN
+  - EVENT
+  - WORK_OF_ART
+  - CONSUMER_GOOD
+  - PRICE
+mistakes_dump_path: pii_recognition/experiments/pii_validation/google_cloud_reports/mistakes_ner.json
+scores_dump_path: pii_recognition/experiments/pii_validation/google_cloud_reports/scores_ner.json
+fbeta: 1.0

--- a/pii_recognition/experiments/pii_validation/google_cloud.yaml
+++ b/pii_recognition/experiments/pii_validation/google_cloud.yaml
@@ -45,7 +45,7 @@ nontargeted_labels:
   - NATIONALITY
   - TITLE
   - ORGANIZATION
-  # comprehend entities being removed
+  # Google NL API entities being removed
   - UNKNOWN
   - EVENT
   - WORK_OF_ART

--- a/pii_recognition/pipelines/pii_validation_pipeline.py
+++ b/pii_recognition/pipelines/pii_validation_pipeline.py
@@ -15,6 +15,7 @@ from pii_recognition.evaluation.character_level_evaluation import (
 from pii_recognition.recognisers import registry as recogniser_registry
 from pii_recognition.recognisers.entity_recogniser import EntityRecogniser
 from pii_recognition.utils import dump_to_json_file, load_yaml_file, stringify_keys
+from tqdm import tqdm
 
 
 @returns(Data)
@@ -35,7 +36,7 @@ def identify_pii_entities(
         recogniser_name, recogniser_params
     )
 
-    for item in data.items:
+    for item in tqdm(data.items):
         item.pred_labels = recogniser.analyse(item.text, recogniser.supported_entities)
     return data
 

--- a/pii_recognition/recognisers/google_recogniser.py
+++ b/pii_recognition/recognisers/google_recogniser.py
@@ -44,10 +44,10 @@ class GoogleRecogniser(EntityRecogniser):
         for entity in response.entities:
             entity_type = entity.type_.name
             for mention in entity.mentions:
-                # Two types of mention: PROPER and COMMON. We are only interested in
-                # PROPER.
+                # Three types of mention: PROPER, COMMON and TYPE_UNKNOWN. We are not
+                # interested in COMMON.
                 # https://cloud.google.com/natural-language/docs/basics#entity_analysis
-                if mention.type_.name == "PROPER":
+                if mention.type_.name != "COMMON":
                     # google is using byte offset
                     byte_begin_offset = mention.text.begin_offset
                     start = indexer.byte_index_to_utf8_index(byte_begin_offset)

--- a/pii_recognition/recognisers/google_recogniser.py
+++ b/pii_recognition/recognisers/google_recogniser.py
@@ -2,8 +2,9 @@ from typing import Dict, List
 
 from decouple import config
 from google.cloud import language_v1
-from google.cloud.language_v1 import LanguageServiceClient
+from google.cloud.language_v1 import AnalyzeEntitiesResponse, LanguageServiceClient
 from pii_recognition.labels.schema import Entity
+from pii_recognition.utils import TextIndexer
 
 from .entity_recogniser import EntityRecogniser
 
@@ -36,6 +37,25 @@ class GoogleRecogniser(EntityRecogniser):
             self.CREDENTIALS_PATH
         )
 
+    def _parse_response(
+        self, response: AnalyzeEntitiesResponse, indexer: TextIndexer
+    ) -> List[Entity]:
+        span_labels = []
+        for entity in response.entities:
+            entity_type = entity.type_.name
+            for mention in entity.mentions:
+                # google is using byte offset
+                byte_begin_offset = mention.text.begin_offset
+                start = indexer.byte_index_to_utf8_index(byte_begin_offset)
+                # content is decoded in chosen langauge which is UTF8
+                text_length = len(mention.text.content)
+                end = start + text_length
+                span_labels.append(
+                    Entity(entity_type=entity_type, start=start, end=end)
+                )
+
+        return span_labels
+
     def analyse(self, text: str, entities: List[str]) -> List[Entity]:
         self.validate_entities(entities)
 
@@ -44,18 +64,7 @@ class GoogleRecogniser(EntityRecogniser):
         request["document"]["content"] = text
 
         response = self.client.analyze_entities(request)
+        text_indexer = TextIndexer(text)
+        span_labels = self._parse_response(response, text_indexer)
 
-        # parse response
-        span_labels = []
-        for entity in response.entities:
-            entity_type = entity.type_.name
-            if entity_type in entities:
-                for mention in entity.mentions:
-                    start = mention.text.begin_offset
-                    text_length = len(mention.text.content)
-                    end = start + text_length
-                    span_labels.append(
-                        Entity(entity_type=entity_type, start=start, end=end)
-                    )
-
-        return span_labels
+        return list(filter(lambda ent: ent.entity_type in entities, span_labels))

--- a/pii_recognition/recognisers/google_recogniser.py
+++ b/pii_recognition/recognisers/google_recogniser.py
@@ -44,15 +44,19 @@ class GoogleRecogniser(EntityRecogniser):
         for entity in response.entities:
             entity_type = entity.type_.name
             for mention in entity.mentions:
-                # google is using byte offset
-                byte_begin_offset = mention.text.begin_offset
-                start = indexer.byte_index_to_utf8_index(byte_begin_offset)
-                # content is decoded in chosen langauge which is UTF8
-                text_length = len(mention.text.content)
-                end = start + text_length
-                span_labels.append(
-                    Entity(entity_type=entity_type, start=start, end=end)
-                )
+                # Two types of mention: PROPER and COMMON. We are only interested in
+                # PROPER.
+                # https://cloud.google.com/natural-language/docs/basics#entity_analysis
+                if mention.type_.name == "PROPER":
+                    # google is using byte offset
+                    byte_begin_offset = mention.text.begin_offset
+                    start = indexer.byte_index_to_utf8_index(byte_begin_offset)
+                    # content is decoded in chosen langauge which is UTF8
+                    text_length = len(mention.text.content)
+                    end = start + text_length
+                    span_labels.append(
+                        Entity(entity_type=entity_type, start=start, end=end)
+                    )
 
         return span_labels
 

--- a/pii_recognition/recognisers/registry_test.py
+++ b/pii_recognition/recognisers/registry_test.py
@@ -33,9 +33,7 @@ def test_registry_for_comprehend(mock_analyse, mock_session):
 
 @patch("pii_recognition.recognisers.google_recogniser.GoogleRecogniser.client")
 @patch("pii_recognition.recognisers.google_recogniser.GoogleRecogniser.analyse")
-def test_registry_for_google_recogniser(
-    mock_analyse, mock_client
-):
+def test_registry_for_google_recogniser(mock_analyse, mock_client):
     mock_analyse.return_value = [Entity("test", 0, 4)]
 
     recogniser_name = "GoogleRecogniser"

--- a/pii_recognition/utils.py
+++ b/pii_recognition/utils.py
@@ -77,7 +77,7 @@ class TextIndexer:
 
     def __init__(self, text: str):
         self.text = text
-        self._byte_to_utf8_mapping = None
+        self._byte_to_utf8_mapping: Optional[Dict[int, int]] = None
 
     @property
     def byte_to_utf8_mapping(self) -> Dict[int, int]:
@@ -90,6 +90,7 @@ class TextIndexer:
                 mapping[byte_index] = utf8_index
 
             self._byte_to_utf8_mapping = mapping
+
         return self._byte_to_utf8_mapping
 
     def byte_index_to_utf8_index(self, byte_index: int) -> int:

--- a/pii_recognition/utils.py
+++ b/pii_recognition/utils.py
@@ -97,6 +97,9 @@ class TextIndexer:
         try:
             return self.byte_to_utf8_mapping[byte_index]
         except KeyError:
+            # The only usage now is Google NL models and so far it does
+            # not cause any failures on index conversion. We may not consider
+            # logics on handling failures until we encouter such cases.
             raise Exception(
                 f"Index {byte_index} is an invalid boundary converting to UTF8."
             )

--- a/pii_recognition/utils.py
+++ b/pii_recognition/utils.py
@@ -70,3 +70,32 @@ def stringify_keys(data: Dict) -> Dict[str, Any]:
             stringify_dict[new_key] = value
 
     return stringify_dict
+
+
+class TextIndexer:
+    """Convert index in one encoding to index in another encoding."""
+
+    def __init__(self, text: str):
+        self.text = text
+        self._byte_to_utf8_mapping = None
+
+    @property
+    def byte_to_utf8_mapping(self) -> Dict[int, int]:
+        if not self._byte_to_utf8_mapping:
+            byte_index = utf8_index = 0
+            mapping = {byte_index: utf8_index}
+            for char in self.text:
+                byte_index += len(char.encode())
+                utf8_index += 1
+                mapping[byte_index] = utf8_index
+
+            self._byte_to_utf8_mapping = mapping
+        return self._byte_to_utf8_mapping
+
+    def byte_index_to_utf8_index(self, byte_index: int) -> int:
+        try:
+            return self.byte_to_utf8_mapping[byte_index]
+        except KeyError:
+            raise Exception(
+                f"Index {byte_index} is an invalid boundary converting to UTF8."
+            )


### PR DESCRIPTION
### Description
This PR adds a config file to run Google Cloud NL models. We realised Google is using byte offsets for indexing rather than string offsets in the chosen language. This would be inconsistent with all other models in the pipeline. To fix the index issue, an `TextIndexer` has been created to convert byte indices to UTF8 indices.

#### Checklist
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.